### PR TITLE
feat: close issues #15, #16, #13 — Docker standards, CI/CD parity, pr…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ python3 -m pytest -x
 | Skill patterns and code recipes | [skills/skills.md](skills/skills.md) |
 | Deterministic utility code | [tools/tools.md](tools/tools.md) |
 | New project onboarding | [templates/onboarding-checklist.md](templates/onboarding-checklist.md) |
+| Containerization patterns | [skills/containerization.md](skills/containerization.md) |
 
 ## Changelog
 

--- a/RULES.md
+++ b/RULES.md
@@ -24,7 +24,7 @@ non-negotiable unless explicitly overridden in writing by a human reviewer.
 14. [Placeholder: Performance Standards](#placeholder-performance-standards)
 15. [Placeholder: Accessibility and Internationalization](#placeholder-accessibility-and-internationalization)
 16. [Placeholder: Data Privacy and Compliance](#placeholder-data-privacy-and-compliance)
-17. [Placeholder: Deployment and Environment Parity](#placeholder-deployment-and-environment-parity)
+17. [Deployment and Environment Parity](#17-deployment-and-environment-parity)
 18. [Code Review and Approval Workflow](#18-code-review-and-approval-workflow)
 
 ---
@@ -483,6 +483,59 @@ directives in addition to every other rule in this file.
 - Every non-trivial decision must include a brief rationale in the response.
 - Never fabricate context, file paths, or behavior — request clarification instead.
 - If a skill invocation fails, log the error and halt unless a fallback is defined.
+
+---
+
+## 17. Deployment and Environment Parity
+
+**Rule:** All deployed services must maintain parity between local development,
+staging, and production. Differences must be limited to environment variable
+values — never to code paths, installed packages, or dependency versions.
+
+### Required Environment Variables per Tier
+
+| Variable | Local | Staging | Production |
+|----------|-------|---------|-----------|
+| `APP_ENV` | `development` | `staging` | `production` |
+| `LOG_LEVEL` | `DEBUG` | `INFO` | `WARNING` |
+| `DATABASE_URL` | local connection string | staging DB URL | prod DB URL |
+| `SECRET_KEY` | any local value | rotated secret | rotated secret |
+
+All required variables must be defined in `.env-template`. Actual values are
+never committed (RULES.md §8).
+
+### Local Development Setup
+
+Use Docker Compose for local multi-service development. See
+`skills/containerization.md` for the canonical `docker-compose.yml` pattern.
+
+```bash
+docker compose up --build   # start all services
+docker compose down         # tear down
+```
+
+### Mandatory CI/CD Gates
+
+All of the following must pass before any deployment proceeds:
+
+1. `pre-commit run --all-files` — secret scanning (§8)
+2. `ruff check .` — no lint errors
+3. `mypy src/` — no type errors
+4. `python3 -m pytest --cov=src --cov-fail-under=100` — full test suite at 100%
+5. `trivy image --exit-code 1 --severity HIGH,CRITICAL <image>:<tag>` — no critical CVEs
+
+No deployment may proceed if any gate fails.
+
+### Blue/Green Deployment Conventions
+
+1. Build and push the new image tagged with the git SHA: `<image>:<sha>`.
+2. Deploy to the green (inactive) environment.
+3. Run smoke tests against green before switching traffic.
+4. Switch the load balancer to green only when all smoke tests pass.
+5. Keep blue (previous version) running for one hour as a rollback target.
+6. Rollback trigger: 5xx error rate >1% sustained for 5 minutes → restore blue.
+
+Agents must not trigger a cutover without human approval (RULES.md §18).
 
 ---
 

--- a/skills/containerization.md
+++ b/skills/containerization.md
@@ -1,0 +1,159 @@
+# Skill: Containerization & Docker
+
+Conventions for containerizing Python projects with Docker. Covers base image
+selection, multi-stage builds, non-root user setup, .dockerignore, image scanning,
+and local development with Docker Compose.
+
+---
+
+## Required Base Image
+
+| Use case | Image |
+|----------|-------|
+| Standard Python service | `python:3.12-slim` |
+| ARM / cross-platform | `python:3.12-slim-bookworm` |
+| Minimal (expert use only) | `python:3.12-alpine` |
+
+Never use `python:latest` — pin the minor version to prevent unexpected upgrades.
+
+---
+
+## Mandatory Multi-Stage Build
+
+All Dockerfiles must use multi-stage builds to keep the runtime image small.
+
+```dockerfile
+# ---- Build stage ----
+FROM python:3.12-slim AS builder
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir uv
+
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev --no-editable
+
+# ---- Runtime stage ----
+FROM python:3.12-slim AS runtime
+
+# Create a non-root user with a fixed UID/GID.
+RUN groupadd --gid 1001 appuser && \
+    useradd --uid 1001 --gid appuser --shell /bin/bash --create-home appuser
+
+WORKDIR /app
+
+COPY --from=builder --chown=appuser:appuser /app/.venv /app/.venv
+COPY --chown=appuser:appuser src/ ./src/
+
+USER appuser
+
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+EXPOSE 8000
+
+CMD ["python3", "-m", "uvicorn", "src.app:app", "--host", "0.0.0.0", "--port", "8000"]
+```
+
+See `templates/Dockerfile` for the ready-to-copy template.
+
+---
+
+## Non-Root User Rules
+
+- Always create a dedicated `appuser` with fixed UID 1001 / GID 1001.
+- Use `COPY --chown=appuser:appuser` on every `COPY` in the runtime stage.
+- Run `RUN` build steps as root; switch to `USER appuser` before `CMD`.
+- Never grant `sudo` or elevated capabilities to the app user.
+
+---
+
+## .dockerignore
+
+Every project with a Dockerfile must include a `.dockerignore`. See
+`templates/.dockerignore` for the canonical list. Required minimum:
+
+```
+.git
+.venv
+__pycache__
+*.pyc
+.env
+.env.*
+!.env-template
+.secrets.baseline
+*.egg-info
+dist/
+build/
+htmlcov/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+```
+
+---
+
+## Container Image Scanning
+
+Scan every image with `trivy` before pushing to any registry:
+
+```bash
+trivy image --exit-code 1 --severity HIGH,CRITICAL <image>:<tag>
+```
+
+| Severity | Policy |
+|----------|--------|
+| CRITICAL | Block — must be resolved before the image is pushed |
+| HIGH | Block if a fix is available; document if not |
+| MEDIUM | Advisory; track and review within 30 days |
+| LOW | Advisory only |
+
+In CI, the trivy scan step must run after build and before push.
+
+---
+
+## Docker Compose (Local Development)
+
+```yaml
+# docker-compose.yml
+services:
+  app:
+    build:
+      context: .
+      target: runtime
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env
+    volumes:
+      - ./src:/app/src:ro
+    depends_on:
+      - db
+
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: appdb
+      POSTGRES_USER: appuser
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+volumes:
+  db_data:
+```
+
+Rules:
+- Never commit credentials in `docker-compose.yml` — use `env_file: .env`.
+- `.env` must be in `.gitignore`.
+- Use named volumes for persistent data; never bind-mount a database directory.
+
+---
+
+## See Also
+
+- `templates/Dockerfile` — ready-to-copy multi-stage Dockerfile
+- `templates/.dockerignore` — canonical .dockerignore
+- `skills/secret-scanning.md` — ensure no secrets land in the image layer
+- `RULES.md §17` — deployment and environment parity rules

--- a/skills/python-testing.md
+++ b/skills/python-testing.md
@@ -400,6 +400,95 @@ boundary only.
 
 ---
 
+## Property-Based Testing (Hypothesis)
+
+Apply to any module that: parses or serializes structured data, performs financial
+or decimal arithmetic, implements sorting/filtering/search, or validates user input.
+
+```bash
+uv add --dev hypothesis
+```
+
+```python
+from decimal import Decimal
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from my_package.tax import calculate_tax
+
+
+@given(
+    income=st.decimals(min_value=0, max_value=1_000_000, places=2),
+    rate=st.decimals(min_value=0, max_value=1, places=4),
+)
+@settings(max_examples=500)
+def test_tax_never_negative(income: Decimal, rate: Decimal) -> None:
+    """Tax result must always be non-negative for valid inputs."""
+    result = calculate_tax(income, rate)
+    assert result >= Decimal("0")
+
+
+@given(st.text(min_size=0, max_size=1000))
+def test_parser_never_crashes(raw: str) -> None:
+    """Parser must handle any string without raising an unhandled exception."""
+    try:
+        parse_record(raw)
+    except ValueError:
+        pass  # expected for invalid input
+```
+
+### Hypothesis Strategies Quick Reference
+
+| Strategy | Use for |
+|----------|---------|
+| `st.integers()` | Integer inputs with optional bounds |
+| `st.decimals()` | Decimal arithmetic testing |
+| `st.text()` | String parsing robustness |
+| `st.lists(st.integers())` | Collection operations |
+| `st.sampled_from([...])` | Enumerated valid values |
+| `st.builds(MyClass, ...)` | Dataclass / model construction |
+
+---
+
+## Mutation Testing (mutmut)
+
+Mutation testing verifies that your tests actually catch logic errors, not just
+execute lines. Apply to modules with 100% unit coverage and financial/legal logic.
+
+```bash
+uv add --dev mutmut
+```
+
+```bash
+# Run against the src/ directory
+mutmut run --paths-to-mutate src/
+
+# Show summary
+mutmut results
+
+# Inspect a specific surviving mutant
+mutmut show <id>
+```
+
+### Interpreting Mutation Scores
+
+| Score | Interpretation |
+|-------|---------------|
+| 90–100% | Excellent — tests catch most logic errors |
+| 75–89% | Acceptable — review surviving mutants for assertion gaps |
+| < 75% | Investigate — surviving mutants indicate under-tested branches |
+
+### CI Integration
+
+Mutation testing is slow. Do not run it on every commit.
+
+- Run as a pre-release gate, not in standard CI.
+- To limit scope: `mutmut run --paths-to-mutate src/<changed-module>.py`
+- Set a minimum score in the release checklist rather than as a hard pipeline gate.
+
+---
+
 ## See Also
 
 - [`skills/python-linting.md`](python-linting.md)

--- a/skills/skills.md
+++ b/skills/skills.md
@@ -27,6 +27,7 @@ recipes, and code cookbooks. They are read on demand when an agent needs to know
 | [`multi-agent.md`](multi-agent.md) | All | Handoff payload schema, context passing, loop detection, logging |
 | [`prompt-engineering.md`](prompt-engineering.md) | All | Prompt structure standards, injection defense, token efficiency |
 | [`cost-management.md`](cost-management.md) | All | LLM token logging, session budget guards, pre-flight cost estimation |
+| [`containerization.md`](containerization.md) | DevOps | Docker multi-stage builds, non-root user, .dockerignore, trivy scanning |
 | [`cli-development.md`](cli-development.md) | CLI | Click/Typer patterns, terminal UI |
 | [`web-development.md`](web-development.md) | Web | FastAPI, Flask, Django patterns |
 | [`api-integration.md`](api-integration.md) | Data/Web | HTTP clients, retry, pagination |

--- a/subagents/registry.json
+++ b/subagents/registry.json
@@ -348,6 +348,20 @@
       "domain": "all",
       "version": "1.0.0",
       "status": "active"
+    },
+    {
+      "file": "skills/containerization.md",
+      "name": "containerization",
+      "domain": "devops",
+      "version": "1.0.0",
+      "status": "active"
+    },
+    {
+      "file": "skills/python-testing.md",
+      "name": "python-testing",
+      "domain": "all",
+      "version": "1.2.0",
+      "status": "active"
     }
   ]
 }

--- a/templates/.dockerignore
+++ b/templates/.dockerignore
@@ -1,0 +1,55 @@
+# .dockerignore — copy to project root alongside Dockerfile
+
+# Version control
+.git
+.gitignore
+
+# Python runtime artifacts
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+
+# Virtual environment
+.venv
+venv
+
+# Environment and secrets
+.env
+.env.*
+!.env-template
+.secrets.baseline
+
+# Build artifacts
+*.egg-info
+dist/
+build/
+
+# Test and coverage artifacts
+htmlcov/
+.coverage
+.pytest_cache/
+.tox/
+
+# Type checker and linter caches
+.mypy_cache/
+.ruff_cache/
+
+# IDE / editor
+.vscode/
+.idea/
+*.swp
+
+# OS artifacts
+.DS_Store
+Thumbs.db
+
+# Docker files (not needed inside the image)
+Dockerfile
+docker-compose*.yml
+.dockerignore
+
+# Documentation
+docs/
+*.md

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -1,0 +1,40 @@
+# Dockerfile template for Python projects using uv.
+#
+# Usage:
+#   1. Copy to your project root as "Dockerfile"
+#   2. Replace <PROJECT_MODULE> with your package's import name (e.g. my_project)
+#   3. Adjust EXPOSE port and CMD entry point as needed
+#   4. Build: docker build -t <image-name> .
+#   5. Run:   docker run --env-file .env -p 8000:8000 <image-name>
+
+# ---- Build stage ----
+FROM python:3.12-slim AS builder
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir uv
+
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev --no-editable
+
+# ---- Runtime stage ----
+FROM python:3.12-slim AS runtime
+
+RUN groupadd --gid 1001 appuser && \
+    useradd --uid 1001 --gid appuser --shell /bin/bash --create-home appuser
+
+WORKDIR /app
+
+COPY --from=builder --chown=appuser:appuser /app/.venv /app/.venv
+COPY --chown=appuser:appuser src/ ./src/
+
+USER appuser
+
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+EXPOSE 8000
+
+CMD ["python3", "-m", "uvicorn", "src.<PROJECT_MODULE>.app:app", \
+     "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
Issue #15 — Containerization: Docker Standards & Image Conventions:
- Add skills/containerization.md: python:3.12-slim base image, multi-stage build pattern, non-root user (UID 1001), COPY --chown rules, .dockerignore standards, trivy scanning severity policy, Docker Compose local dev pattern
- Add templates/Dockerfile: ready-to-copy multi-stage Python template
- Add templates/.dockerignore: canonical ignore list
- Register in skills/skills.md and subagents/registry.json
- Add to AGENTS.md on-demand resources table

Issue #16 — Containerization & CI/CD: Environment Parity & Pipeline Gates:
- Fill RULES.md §17 (was empty placeholder): environment parity rule, required env vars per tier, local dev Docker Compose setup, mandatory CI/CD gates (pre-commit + ruff + mypy + pytest + trivy), blue/green deployment conventions
- Update ToC anchor for §17

Issue #13 — Testing: Property-Based & Mutation Testing Strategy:
- Expand skills/python-testing.md with two new sections: Property-Based Testing (Hypothesis) — when to apply, @given/@settings pattern, strategies quick reference table Mutation Testing (mutmut) — run commands, score interpretation table, CI integration guidance (pre-release gate, not standard CI)
- Bump python-testing version to 1.2.0 in registry.json

Closes #15, #16, #13