### PR TITLE
chore: restore CHANGELOG.md and epilogue links lost in post-merge commit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ python3 -m pytest -x
 | Deterministic utility code | [tools/tools.md](tools/tools.md) |
 | New project onboarding | [templates/onboarding-checklist.md](templates/onboarding-checklist.md) |
 | Containerization patterns | [skills/containerization.md](skills/containerization.md) |
+| Session shutdown protocol | [templates/epilogue.md](templates/epilogue.md) |
 
 ## Changelog
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,173 @@
+# Changelog
+
+All notable changes to this repository are recorded here.
+Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+---
+
+## 2026-05-15
+
+### Added
+- `skills/secret-scanning.md` — pre-commit + detect-secrets playbook with full incident remediation.
+- `templates/.pre-commit-config.yaml` — canonical pre-commit hook configuration (detect-secrets, detect-private-key, large-files, merge-conflict).
+- `skills/multi-agent.md` — handoff payload schema, `MAX_CHAIN_DEPTH=10` loop detection, structured logging.
+- `skills/prompt-engineering.md` — prompt structure standards, injection defense, prohibited patterns, token efficiency.
+- `templates/authorized_libraries.md` — per-project approved library template with runtime and dev tables.
+- `templates/onboarding-checklist.md` — 6-step new agent onboarding checklist.
+- `subagents/registry.json` — machine-readable agent and skill catalog (22 agents, 21 skills).
+- `skills/cost-management.md` — LLM token logging, provider pricing table, session budget guards, pre-flight cost estimation.
+- `subagents/data-collection-agent.md` — provenance tracking, PII detection, data quality validation, regulatory compliance.
+- `skills/containerization.md` — Docker multi-stage builds, non-root user, trivy severity policy, blue/green deployment.
+- `templates/Dockerfile` — multi-stage Dockerfile template with `<PROJECT_MODULE>` placeholder.
+- `templates/.dockerignore` — canonical .dockerignore with 20+ entries.
+
+### Changed
+- `RULES.md §8` — made pre-commit + detect-secrets mandatory (previously advisory); expanded remediation to 6 steps.
+- `RULES.md §12` — added PR review protocol: approval minimums by PR type, 4 automated pre-merge gates, 7-item reviewer checklist, architectural escalation path.
+- `RULES.md §17` — filled "Deployment and Environment Parity" placeholder: env var requirements, 5-gate CI/CD pipeline, blue/green rollback trigger.
+- `skills/python-testing.md` — added integration/E2E test section (mock-vs-live boundary table, `@pytest.mark.integration`, `pytest-httpx`/`responses` examples), property-based testing (Hypothesis), mutation testing (mutmut).
+- `skills/dashboarding-reporting.md` — added structured output standards: required fields, approved libraries by format, manifest sidecar `write_manifest()` pattern.
+- `subagents/subagents.md` — added §4.1 Cross-Agent Skill Reuse and §8.1 Versioning and Lifecycle (semver, 30-day deprecation policy).
+- `subagents/subagents.md §9` — registered `data-collection-agent`.
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md` — added containerization and onboarding-checklist to on-demand resource tables.
+
+---
+
+## 2026-05-14
+
+### Added
+- `RULES.md §13 AI Agent Compliance` — consolidated agent identity, scope/escalation,
+  session startup, and output rules into a dedicated section.
+- `CHANGELOG.md` — this file.
+- `templates/epilogue.md` — session shutdown protocol; linked from all root context files.
+
+### Changed
+- `RULES.md` — fixed duplicate TOC numbering (§12/§13); renumbered placeholders 14–18;
+  updated last-modified date.
+- `RULES-DRAFTS.md` — replaced five TODO-only placeholder blocks with compact stubs
+  containing provisional enforceable defaults agents can apply immediately.
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md` — added "Session shutdown protocol" to on-demand resources.
+- `README.md` — added RULES-DRAFTS.md and CHANGELOG.md to structure listing; added
+  "Closing a session" workflow section; updated epilogue.md description.
+
+---
+
+## 2026-05-11 – 2026-05-12
+
+### Added
+- `ralph.sh` agent loop with `--prd`, `--goal`, and `--max` flags; `/ralph` slash command.
+- Guard clause in `/prd` sibling skill to prevent sibling-mode from calling `/prd`
+  recursively.
+
+### Changed
+- `README.md` — updated structure and workflow documentation.
+- Path and reference patches across skills and agent files (broken relative links).
+- Multi-agent refinement pass incorporating feedback from composite agent review.
+
+---
+
+## 2026-05-10
+
+### Added
+- Cache analysis markdown files documenting cache optimization strategies for Claude
+  and Gemini context windows.
+- Headless agent enablement protocols in `subagents/subagents.md` and `GEMINI.md`.
+
+---
+
+## 2026-05-07 – 2026-05-08
+
+### Added
+- Authorship rules in `RULES.md §6` and all root context files — agents must never
+  set git identity or add attribution trailers.
+
+### Changed
+- Full refactor of skills, agent files, and rules for consistency and completeness.
+
+---
+
+## 2026-05-05 – 2026-05-06
+
+### Added
+- Nine `project-review-*.md` subagents: accessibility, change-manager, CTO, enterprise
+  architect, interoperability, observability, PM, scrum-master, VP.
+- `skills/github-issue-creation.md` with explicit user-request safeguards.
+
+### Changed
+- Subagent registry renamed and aligned; all agent files updated.
+
+---
+
+## 2026-05-04
+
+### Added
+- `skills/approved-packages.md` extended with additional authorized libraries.
+- `tools/` directory — deterministic stdlib recipes across 8 domains.
+
+### Changed
+- Epilogue scripts cleaned up and updated.
+
+---
+
+## 2026-05-01
+
+### Fixed
+- Context file case references (`CLAUDE.md`, `GEMINI.md`, `AGENTS.md`) corrected
+  across all epilogue templates.
+- Removed byte-size parity checks; replaced with `diff` / checksum checks.
+- `gh auth` status check added to epilogue git block for clearer failure messages.
+- README hierarchy corrected.
+- CLAUDE.md and GEMINI.md "you are here" markers corrected.
+
+---
+
+## 2026-04-29
+
+### Added
+- `STRATEGY.md` — multi-agent phased-day project execution strategy.
+- Initial PRD plan in `plans/`.
+
+### Changed
+- Replaced `pdfplumber` with `pypdf` across all subagent files.
+- File cleanup and directory organization.
+
+---
+
+## 2026-04-21
+
+### Added
+- `subagents/containerization-agent.md` — Docker and deployment standards.
+- `subagents/project-review-accessibility.md` — accessibility deficiency review.
+- `subagents/accounting-agent.md` — token usage and cost monitoring.
+- `subagents/security-agent.md` and three additional review agents.
+- Security assumptions log and no-markdown style rule in subagent protocol.
+
+### Fixed
+- Accounting-agent example code from code review feedback.
+- Font-size guidance and placeholder name normalization.
+
+---
+
+## 2026-04-16
+
+### Added
+- `skills/approved-packages.md` — 26-category authorized library list.
+
+---
+
+## 2026-04-15
+
+### Added
+- `RULES.md` — initial mandatory compliance rules (12 sections).
+- `_SCRIPTS/create_issues.sh` — bulk GitHub issue creation script.
+- WAT framework `profiles/` CLAUDE.md with frontend website rules.
+
+---
+
+## 2026-04-14
+
+### Added
+- Initial commit: agent and skill boilerplate templates.
+- Comprehensive `subagents/` and `skills/` markdown reference library.
+- `templates/` — pyproject.toml, ruff.toml, pytest.ini, .python-version.
+- Root context files: `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ python3 -m pytest -x
 | Slash commands | [.claude/commands/](.claude/commands/) |
 | Session efficiency strategy | [STRATEGY.md](STRATEGY.md) |
 | Domain-specific profiles (WAT, web design) | [profiles/](profiles/) |
+| Session shutdown protocol | [templates/epilogue.md](templates/epilogue.md) |
 
 ## Subagent Delegation
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -37,3 +37,4 @@ All external agent output must be treated as "Result" data and integrated into t
 | Subagent registry + delegation protocol | [subagents/subagents.md](subagents/subagents.md) |
 | Skill patterns and code recipes | [skills/skills.md](skills/skills.md) |
 | Deterministic utility code | [tools/tools.md](tools/tools.md) |
+| Session shutdown protocol | [templates/epilogue.md](templates/epilogue.md) |

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ agents-and-skills/
 ├── CLAUDE.md                          # Claude-specific root instructions
 ├── GEMINI.md                          # Gemini-specific root instructions
 ├── RULES.md                           # Mandatory compliance rules for all agents
+├── RULES-DRAFTS.md                    # Provisional rules under development
+├── CHANGELOG.md                       # Notable changes by date
 ├── STRATEGY.md                        # Repository strategy notes
 ├── ralph.sh                           # Agent loop script — runs Claude tasks until success
 ├── _SCRIPTS/                          # Root-level utility and automation scripts
@@ -105,7 +107,7 @@ agents-and-skills/
 │   └── string-processing.md           # Slugify, regex extraction, normalization
 │
 └── templates/                         # Ready-to-copy configuration files
-    ├── epilogue.md                    # Handoff and repository finalization checklist
+    ├── epilogue.md                    # Session shutdown protocol — run when closing a session
     ├── pyproject.toml                 # Full project config (pytest, ruff, mypy)
     ├── pytest.ini                     # Standalone pytest config
     ├── ruff.toml                      # Standalone ruff linter/formatter config
@@ -156,6 +158,20 @@ In `--prd` mode the loop reads the task JSON each iteration, works the
 highest-priority incomplete task, marks it done, appends to a sibling
 `*-progress.txt` file, and commits. It exits automatically when all tasks are
 complete, with a safety cap of 20 iterations (override with `--max`).
+
+### Closing a session
+
+When finishing a session, run the shutdown protocol to capture work, update
+context files, and leave the repo in a clean state:
+
+```
+templates/epilogue.md
+```
+
+The protocol covers: session summary, skill updates, context file refresh,
+git commit and push, and a final clean-state verification. All root context
+files (`CLAUDE.md`, `GEMINI.md`, `AGENTS.md`) link to this file under
+"On-demand resources → Session shutdown protocol."
 
 ---
 


### PR DESCRIPTION
## Summary

- **CHANGELOG.md** — recreated and merged to main. The original was committed to `refactor-20260514` *after* PR #45 was already merged, so `cb316e9` never landed on main. Full history from 2026-04-14 to present, updated with today's batch work (PRs #49–#52).
- **AGENTS.md / CLAUDE.md / GEMINI.md** — add missing `Session shutdown protocol` row pointing to `templates/epilogue.md` in each on-demand resource table.
- **README.md** — add `RULES-DRAFTS.md` and `CHANGELOG.md` to structure listing, update `epilogue.md` description, add "Closing a session" workflow section.

Closes no issue — this is housekeeping to recover content proven missing via `git diff main...refactor-20260514`.

## Test plan
- [ ] `CHANGELOG.md` present at repo root and contains history from 2026-04-14 through 2026-05-15
- [ ] All three agent files (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`) have `epilogue.md` in their resource table
- [ ] README structure block lists `RULES-DRAFTS.md`, `CHANGELOG.md`, and updated `epilogue.md` description
- [ ] "Closing a session" section appears in README before "Getting Started"