### PR TITLE
feat: close issues #23, #14 — a11y/i18n rules and release workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## 2026-05-15 (batch 3)
+
+### Added
+- `subagents/release-agent.md` — end-to-end PyPI release workflow: semver policy, CHANGELOG format, CI gates, `uv publish` / `twine` steps, PyPI token security, GitHub Release creation.
+
+### Changed
+- `RULES.md §15` — filled "Accessibility and Internationalization" placeholder: WCAG 2.1 AA criteria table, `axe-core` CLI testing requirement, CLI `NO_COLOR` rule, `babel`/`zoneinfo`/`gettext` i18n standards, scope exceptions for internal tools.
+- `subagents/subagents.md §9` — registered `release-agent`.
+- `subagents/registry.json` — added `release-agent` entry.
+
+---
+
 ## 2026-05-15 (batch 2)
 
 ### Changed

--- a/RULES.md
+++ b/RULES.md
@@ -22,7 +22,7 @@ non-negotiable unless explicitly overridden in writing by a human reviewer.
 12. [Local-Only Agent Directory](#12-local-only-agent-directory)
 13. [AI Agent Compliance](#13-ai-agent-compliance)
 14. [Performance Standards](#14-performance-standards)
-15. [Placeholder: Accessibility and Internationalization](#placeholder-accessibility-and-internationalization)
+15. [Accessibility and Internationalization](#15-accessibility-and-internationalization)
 16. [Data Privacy and Compliance](#16-data-privacy-and-compliance)
 17. [Deployment and Environment Parity](#17-deployment-and-environment-parity)
 18. [Code Review and Approval Workflow](#18-code-review-and-approval-workflow)
@@ -549,6 +549,98 @@ the project owner before merging.
 
 ---
 
+## 15. Accessibility and Internationalization
+
+**Rule:** Any web UI, CLI output, or document produced by an agent must meet
+the accessibility and internationalization standards below. These apply when the
+project serves end users — not to internal tooling or agent-only pipelines.
+
+### Web UI — WCAG 2.1 AA Compliance
+
+All agent-generated web interfaces must satisfy WCAG 2.1 Level AA:
+
+| Criterion | Requirement |
+|-----------|------------|
+| Color contrast | Text/background ratio ≥ 4.5:1 (normal text), ≥ 3:1 (large text) |
+| Keyboard navigation | All interactive elements reachable and operable via keyboard alone |
+| Focus indicators | Visible focus ring on all focusable elements |
+| Alt text | Every non-decorative image has a descriptive `alt` attribute |
+| Form labels | Every input has an associated `<label>` or `aria-label` |
+| Error messages | Errors identified in text — never by color alone |
+| Heading structure | Headings used semantically (`h1`→`h2`→`h3`), not for styling |
+
+Required accessibility testing before any web UI ships:
+
+```bash
+# axe-core CLI (install once)
+npm install -g @axe-core/cli
+
+# Run against a running local server
+axe http://localhost:8000 --exit
+```
+
+Zero WCAG 2.1 AA violations allowed. Critical and serious violations block the
+PR; moderate violations must be documented as known issues with a remediation
+timeline.
+
+### CLI — Color and Terminal Output
+
+- Never use color as the sole means of conveying information (e.g., red = error,
+  green = success must also include a text label).
+- Test with `NO_COLOR=1` — all output must be fully readable in plain text.
+- Minimum contrast for terminal color pairs: verify with the ANSI color contrast
+  table in `skills/cli-development.md`.
+
+### Internationalization (i18n)
+
+**Locale and timezone:**
+
+```python
+from zoneinfo import ZoneInfo
+
+# Always use explicit timezone — never datetime.now() without tz
+from datetime import datetime
+now = datetime.now(tz=ZoneInfo("UTC"))
+
+# Format for display using babel (locale-aware)
+from babel.dates import format_datetime
+display = format_datetime(now, locale="en_US")
+```
+
+Approved i18n libraries:
+
+| Library | Install | Use for |
+|---------|---------|--------|
+| `zoneinfo` | stdlib (3.9+) | Timezone-aware datetimes |
+| `babel` | `uv add babel` | Locale-aware date, number, currency formatting |
+| `gettext` | stdlib | String externalization for translated UIs |
+
+**String externalization rules:**
+
+- All user-visible strings in web UIs must be wrapped in `gettext` calls (`_("...")`).
+- Source strings are English; translations live in `locale/<lang>/LC_MESSAGES/`.
+- Do not concatenate translated strings — use format strings with named placeholders:
+  ```python
+  # Correct
+  _("Found {count} records").format(count=n)
+  # Wrong — breaks in languages with different word order
+  _("Found") + f" {n} " + _("records")
+  ```
+- Dates, numbers, and currency must use `babel` formatters, never f-strings, when
+  locale-aware output is required.
+
+### Scope Exceptions
+
+These rules apply only when the project:
+- Serves end users via a web browser or terminal interface, **and**
+- Targets a locale other than the deployment default (for i18n string rules).
+
+Pure data pipelines, internal CLI tools, and agent-only scripts are exempt from
+the WCAG and i18n string externalization requirements, but must still follow
+the color/`NO_COLOR` rule for any terminal output.
+
+---
+
 ## 16. Data Privacy and Compliance
 
 **Rule:** All agents must handle personal and sensitive data according to the
@@ -765,6 +857,7 @@ Architectural decisions require:
 
 | Date | Change |
 |------|--------|
+| 2026-05-15 | §15: Accessibility and Internationalization filled — WCAG 2.1 AA criteria, axe-core testing, CLI NO_COLOR rule, babel/zoneinfo/gettext i18n standards, scope exceptions. |
 | 2026-05-15 | §14: Performance Standards filled — latency targets, memory limits, approved profiling tools, caching libraries, regression escalation criteria. |
 | 2026-05-15 | §16: Data Privacy and Compliance filled — classification levels, PII handling, anonymization, retention/deletion policy, audit trail schema, GDPR/CCPA/HIPAA obligations. |
 | 2026-05-14 | §8: pre-commit hook requirement made mandatory; reference to `skills/secret-scanning.md` and `templates/.pre-commit-config.yaml` added. Remediation steps expanded. |

--- a/subagents/registry.json
+++ b/subagents/registry.json
@@ -199,6 +199,15 @@
       "status": "active",
       "role": "Audit and implement data collection pipelines: provenance, quality, PII, compliance",
       "skills_used": ["api-integration", "database-access", "python-testing", "logging-observability", "configuration-management"]
+    },
+    {
+      "file": "subagents/release-agent.md",
+      "name": "release-agent",
+      "domain": "publishing",
+      "version": "1.0.0",
+      "status": "active",
+      "role": "Manage PyPI package releases: semver, CHANGELOG, build, publish, GitHub Release",
+      "skills_used": ["python-uv-workflow", "secret-scanning", "python-testing"]
     }
   ],
   "skills": [

--- a/subagents/release-agent.md
+++ b/subagents/release-agent.md
@@ -1,0 +1,189 @@
+# Release Agent Instructions
+
+This file extends `AGENTS.md` with instructions specific to publishing
+**Python packages to PyPI**. Read root `AGENTS.md` and `RULES.md` first.
+
+---
+
+## Purpose
+
+The release agent manages the end-to-end workflow for cutting a versioned
+release: bumping version, updating `CHANGELOG.md`, building and publishing
+the distribution, and tagging the commit. It never bypasses CI gates.
+
+---
+
+## Versioning Policy
+
+Follow [Semantic Versioning 2.0.0](https://semver.org/):
+
+| Change type | Version bump | Example |
+|-------------|-------------|---------|
+| Breaking change to public API | MAJOR | 1.2.3 → 2.0.0 |
+| New backward-compatible feature | MINOR | 1.2.3 → 1.3.0 |
+| Bug fix, patch, or dependency bump | PATCH | 1.2.3 → 1.2.4 |
+
+Rules:
+- Version lives in `pyproject.toml` under `[project] version`.
+- Never set `version = "0.0.0"` in production; start at `0.1.0` for pre-release,
+  `1.0.0` when the public API is stable.
+- Do not use `setuptools-scm` or dynamic versioning unless explicitly authorized.
+- Pre-release identifiers: `1.0.0a1`, `1.0.0b1`, `1.0.0rc1`.
+
+---
+
+## CHANGELOG.md Format
+
+Follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+```markdown
+# Changelog
+
+## [Unreleased]
+
+### Added
+- Short description of new feature.
+
+### Changed
+- Short description of changed behavior.
+
+### Fixed
+- Short description of bug fix.
+
+## [1.2.3] — 2026-05-15
+
+### Fixed
+- Corrected off-by-one error in pagination helper.
+
+[Unreleased]: https://github.com/org/repo/compare/v1.2.3...HEAD
+[1.2.3]: https://github.com/org/repo/compare/v1.2.2...v1.2.3
+```
+
+Rules:
+- Every user-visible change goes in `[Unreleased]` during development.
+- When cutting a release, rename `[Unreleased]` to `[X.Y.Z] — <date>` and add a
+  new empty `[Unreleased]` section above it.
+- Use exactly these subsections: `Added`, `Changed`, `Deprecated`, `Removed`,
+  `Fixed`, `Security`. Do not invent new subsection names.
+- Keep entries short (one sentence). Do not include internal refactors unless they
+  affect public API behavior.
+
+---
+
+## Required CI Gates Before Release
+
+All of the following must pass on the release commit before tagging:
+
+```bash
+pre-commit run --all-files          # secret scanning (RULES.md §8)
+ruff check .                        # no lint errors
+mypy src/                           # no type errors
+python3 -m pytest --cov=src --cov-fail-under=100   # 100% coverage
+pip-audit                           # no known dependency vulnerabilities
+```
+
+A release tag must not be created if any gate fails. No exceptions.
+
+---
+
+## Build and Publish Workflow
+
+### 1. Verify clean working tree
+
+```bash
+git status          # must be clean
+git log --oneline -5
+```
+
+### 2. Bump version in `pyproject.toml`
+
+Edit `[project] version` manually. Then verify the package builds cleanly:
+
+```bash
+uv build
+```
+
+The `dist/` directory must contain both a `.tar.gz` (sdist) and a `.whl` (wheel).
+
+### 3. Update CHANGELOG.md
+
+- Move all items from `[Unreleased]` into the new versioned section.
+- Add comparison links at the bottom.
+- Commit: `chore: release vX.Y.Z`.
+
+### 4. Tag the release
+
+```bash
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git push origin main --tags
+```
+
+### 5. Publish to PyPI
+
+```bash
+uv publish
+```
+
+`uv publish` reads credentials from the environment. Never pass tokens on the
+command line or store them in any file.
+
+#### Credential storage
+
+| Environment | Token source |
+|-------------|-------------|
+| Local dev | `PYPI_TOKEN` env var (set in shell; never in `.env` file) |
+| GitHub Actions | `secrets.PYPI_TOKEN` repository secret |
+
+GitHub Actions publish step:
+
+```yaml
+- name: Publish to PyPI
+  env:
+    UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
+  run: uv publish
+```
+
+Fallback (if `uv publish` is unavailable): `twine upload dist/*` with
+`TWINE_PASSWORD` set from the same secret. Do not use `--skip-existing`.
+
+### 6. Create GitHub Release
+
+```bash
+gh release create vX.Y.Z dist/* \
+  --title "vX.Y.Z" \
+  --notes "$(sed -n '/## \[X.Y.Z\]/,/## \[/p' CHANGELOG.md | head -n -1)"
+```
+
+Attach the `dist/` artifacts to the release.
+
+---
+
+## PyPI Token Security
+
+- Tokens are scoped to a single project — never use an account-wide token.
+- Rotate tokens immediately if exposed. Report via `skills/secret-scanning.md`
+  incident procedure.
+- Store only in GitHub Actions secrets or a local secrets manager (`pass`,
+  `1Password CLI`). Never commit, log, or print.
+
+---
+
+## Pre-release Checklist
+
+- [ ] Version bumped in `pyproject.toml`
+- [ ] `CHANGELOG.md` updated: `[Unreleased]` → `[X.Y.Z] — <date>`
+- [ ] All CI gates pass on the release commit
+- [ ] `uv build` produces `.whl` and `.tar.gz` without errors
+- [ ] `git tag vX.Y.Z` created and pushed
+- [ ] `uv publish` succeeded; package visible on PyPI within 5 minutes
+- [ ] GitHub Release created with `dist/` artifacts attached
+- [ ] New empty `[Unreleased]` section added to `CHANGELOG.md`
+
+---
+
+## See Also
+
+- [`RULES.md §7`](../RULES.md#7-testing-and-coverage) — 100% coverage gate
+- [`RULES.md §8`](../RULES.md#8-security-and-secrets) — secret scanning before release
+- [`skills/python-uv-workflow.md`](../skills/python-uv-workflow.md) — `uv` package manager reference
+- [`skills/secret-scanning.md`](../skills/secret-scanning.md) — token incident response

--- a/subagents/subagents.md
+++ b/subagents/subagents.md
@@ -233,6 +233,7 @@ modified to a new MINOR/MAJOR version, deprecated, or removed.
 | [`project-review-interoperability.md`](project-review-interoperability.md) | Ad hoc review: API contracts, protocol correctness, and integration compatibility |
 | [`project-review-observability.md`](project-review-observability.md) | Ad hoc review: logging, metrics, tracing, and audit log coverage |
 | [`data-collection-agent.md`](data-collection-agent.md) | Audit and implement data collection pipelines: provenance, quality, PII, compliance |
+| [`release-agent.md`](release-agent.md) | Manage PyPI package releases: semver, CHANGELOG, build, publish, GitHub Release |
 
 ---
 


### PR DESCRIPTION
## Summary

**§15 — Accessibility and Internationalization** (closes #23)
- WCAG 2.1 AA compliance criteria table: contrast, keyboard nav, focus, alt text, form labels, error messages, heading structure
- `axe-core` CLI as required testing tool; zero AA violations before ship
- CLI `NO_COLOR=1` rule: color never sole information channel
- Approved i18n libraries: `zoneinfo` (stdlib), `babel`, `gettext`
- String externalization rules with named-placeholder format pattern (breaks for non-English word order)
- Scope exceptions for internal tools and pure data pipelines

**`subagents/release-agent.md`** (closes #14)
- Semver policy with MAJOR/MINOR/PATCH decision table and pre-release identifiers
- Keep a Changelog format: required subsections, comparison links, `[Unreleased]` workflow
- Required CI gates before any tag: `pre-commit`, `ruff`, `mypy`, `pytest --cov-fail-under=100`, `pip-audit`
- Build and publish steps: `uv build` → CHANGELOG update → `git tag` → `uv publish`
- PyPI token security: project-scoped tokens only; GitHub Actions `secrets.PYPI_TOKEN` pattern
- `twine` fallback documented; GitHub Release creation via `gh release create`
- Pre-release checklist (8 items)

Also registers `release-agent` in `subagents/subagents.md §9` and `subagents/registry.json`.
Updates `RULES.md` ToC (§15 title), `RULES.md` Changelog, and `CHANGELOG.md`.

## Test plan
- [ ] `RULES.md` ToC §15 links to real anchor (not "Placeholder")
- [ ] §15 body present between §14 and §16
- [ ] `subagents/release-agent.md` exists with all sections
- [ ] `release-agent` in `subagents/subagents.md §9` table
- [ ] `release-agent` entry in `subagents/registry.json`
- [ ] `RULES.md` and `CHANGELOG.md` updated