### PR TITLE
feat: close issues #26, #18 — ops patterns and cloud cost guidelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,25 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## 2026-05-15 (batch 4)
+
+### Added
+- `skills/infrastructure-operations.md` — feature flags (env-var, flagsmith, launchdarkly patterns; lifecycle rules), canary/blue-green smoke tests and success metrics table, rollback procedure with `gh issue create` step.
+- `skills/cloud-cost-management.md` — required resource tagging table, automated budget alert thresholds, right-sizing recommendations by workload type, cost-review PR checklist.
+
+### Changed
+- `skills/api-integration.md` — added Rate Limiting and 429/503 Handling section: `_is_retryable` / `_get_retry_after` helpers, `@retry` decorator with `Retry-After` honor, per-status rules table.
+- `skills/web-development.md` — added Health Check Convention section: `/health` (liveness) and `/ready` (readiness) FastAPI pattern, probe rules table, Docker Compose `healthcheck` stanza.
+- `skills/secret-scanning.md` — added Credential Rotation Scheduling section: rotation schedule by credential type, `.credential-manifest.json` pattern, `check_credential_expiry()` helper, 6-step rotation procedure.
+- `skills/skills.md` — registered `infrastructure-operations.md` and `cloud-cost-management.md`; updated `secret-scanning.md` description.
+- Replaced `semver` with "semantic versioning" across `CHANGELOG.md`, `subagents/registry.json`, `subagents/subagents.md`, `subagents/project-review-interoperability.md`.
+
+---
+
 ## 2026-05-15 (batch 3)
 
 ### Added
-- `subagents/release-agent.md` — end-to-end PyPI release workflow: semver policy, CHANGELOG format, CI gates, `uv publish` / `twine` steps, PyPI token security, GitHub Release creation.
+- `subagents/release-agent.md` — end-to-end PyPI release workflow: semantic versioning policy, CHANGELOG format, CI gates, `uv publish` / `twine` steps, PyPI token security, GitHub Release creation.
 
 ### Changed
 - `RULES.md §15` — filled "Accessibility and Internationalization" placeholder: WCAG 2.1 AA criteria table, `axe-core` CLI testing requirement, CLI `NO_COLOR` rule, `babel`/`zoneinfo`/`gettext` i18n standards, scope exceptions for internal tools.
@@ -47,7 +62,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `RULES.md §17` — filled "Deployment and Environment Parity" placeholder: env var requirements, 5-gate CI/CD pipeline, blue/green rollback trigger.
 - `skills/python-testing.md` — added integration/E2E test section (mock-vs-live boundary table, `@pytest.mark.integration`, `pytest-httpx`/`responses` examples), property-based testing (Hypothesis), mutation testing (mutmut).
 - `skills/dashboarding-reporting.md` — added structured output standards: required fields, approved libraries by format, manifest sidecar `write_manifest()` pattern.
-- `subagents/subagents.md` — added §4.1 Cross-Agent Skill Reuse and §8.1 Versioning and Lifecycle (semver, 30-day deprecation policy).
+- `subagents/subagents.md` — added §4.1 Cross-Agent Skill Reuse and §8.1 Versioning and Lifecycle (semantic versioning, 30-day deprecation policy).
 - `subagents/subagents.md §9` — registered `data-collection-agent`.
 - `AGENTS.md`, `CLAUDE.md`, `GEMINI.md` — added containerization and onboarding-checklist to on-demand resource tables.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## 2026-05-15 (batch 3)
+
+### Added
+- `subagents/release-agent.md` — end-to-end PyPI release workflow: semver policy, CHANGELOG format, CI gates, `uv publish` / `twine` steps, PyPI token security, GitHub Release creation.
+
+### Changed
+- `RULES.md §15` — filled "Accessibility and Internationalization" placeholder: WCAG 2.1 AA criteria table, `axe-core` CLI testing requirement, CLI `NO_COLOR` rule, `babel`/`zoneinfo`/`gettext` i18n standards, scope exceptions for internal tools.
+- `subagents/subagents.md §9` — registered `release-agent`.
+- `subagents/registry.json` — added `release-agent` entry.
+
+---
+
 ## 2026-05-15 (batch 2)
 
 ### Changed

--- a/RULES.md
+++ b/RULES.md
@@ -22,7 +22,7 @@ non-negotiable unless explicitly overridden in writing by a human reviewer.
 12. [Local-Only Agent Directory](#12-local-only-agent-directory)
 13. [AI Agent Compliance](#13-ai-agent-compliance)
 14. [Performance Standards](#14-performance-standards)
-15. [Placeholder: Accessibility and Internationalization](#placeholder-accessibility-and-internationalization)
+15. [Accessibility and Internationalization](#15-accessibility-and-internationalization)
 16. [Data Privacy and Compliance](#16-data-privacy-and-compliance)
 17. [Deployment and Environment Parity](#17-deployment-and-environment-parity)
 18. [Code Review and Approval Workflow](#18-code-review-and-approval-workflow)
@@ -549,6 +549,98 @@ the project owner before merging.
 
 ---
 
+## 15. Accessibility and Internationalization
+
+**Rule:** Any web UI, CLI output, or document produced by an agent must meet
+the accessibility and internationalization standards below. These apply when the
+project serves end users — not to internal tooling or agent-only pipelines.
+
+### Web UI — WCAG 2.1 AA Compliance
+
+All agent-generated web interfaces must satisfy WCAG 2.1 Level AA:
+
+| Criterion | Requirement |
+|-----------|------------|
+| Color contrast | Text/background ratio ≥ 4.5:1 (normal text), ≥ 3:1 (large text) |
+| Keyboard navigation | All interactive elements reachable and operable via keyboard alone |
+| Focus indicators | Visible focus ring on all focusable elements |
+| Alt text | Every non-decorative image has a descriptive `alt` attribute |
+| Form labels | Every input has an associated `<label>` or `aria-label` |
+| Error messages | Errors identified in text — never by color alone |
+| Heading structure | Headings used semantically (`h1`→`h2`→`h3`), not for styling |
+
+Required accessibility testing before any web UI ships:
+
+```bash
+# axe-core CLI (install once)
+npm install -g @axe-core/cli
+
+# Run against a running local server
+axe http://localhost:8000 --exit
+```
+
+Zero WCAG 2.1 AA violations allowed. Critical and serious violations block the
+PR; moderate violations must be documented as known issues with a remediation
+timeline.
+
+### CLI — Color and Terminal Output
+
+- Never use color as the sole means of conveying information (e.g., red = error,
+  green = success must also include a text label).
+- Test with `NO_COLOR=1` — all output must be fully readable in plain text.
+- Minimum contrast for terminal color pairs: verify with the ANSI color contrast
+  table in `skills/cli-development.md`.
+
+### Internationalization (i18n)
+
+**Locale and timezone:**
+
+```python
+from zoneinfo import ZoneInfo
+
+# Always use explicit timezone — never datetime.now() without tz
+from datetime import datetime
+now = datetime.now(tz=ZoneInfo("UTC"))
+
+# Format for display using babel (locale-aware)
+from babel.dates import format_datetime
+display = format_datetime(now, locale="en_US")
+```
+
+Approved i18n libraries:
+
+| Library | Install | Use for |
+|---------|---------|--------|
+| `zoneinfo` | stdlib (3.9+) | Timezone-aware datetimes |
+| `babel` | `uv add babel` | Locale-aware date, number, currency formatting |
+| `gettext` | stdlib | String externalization for translated UIs |
+
+**String externalization rules:**
+
+- All user-visible strings in web UIs must be wrapped in `gettext` calls (`_("...")`).
+- Source strings are English; translations live in `locale/<lang>/LC_MESSAGES/`.
+- Do not concatenate translated strings — use format strings with named placeholders:
+  ```python
+  # Correct
+  _("Found {count} records").format(count=n)
+  # Wrong — breaks in languages with different word order
+  _("Found") + f" {n} " + _("records")
+  ```
+- Dates, numbers, and currency must use `babel` formatters, never f-strings, when
+  locale-aware output is required.
+
+### Scope Exceptions
+
+These rules apply only when the project:
+- Serves end users via a web browser or terminal interface, **and**
+- Targets a locale other than the deployment default (for i18n string rules).
+
+Pure data pipelines, internal CLI tools, and agent-only scripts are exempt from
+the WCAG and i18n string externalization requirements, but must still follow
+the color/`NO_COLOR` rule for any terminal output.
+
+---
+
 ## 16. Data Privacy and Compliance
 
 **Rule:** All agents must handle personal and sensitive data according to the
@@ -765,6 +857,7 @@ Architectural decisions require:
 
 | Date | Change |
 |------|--------|
+| 2026-05-15 | §15: Accessibility and Internationalization filled — WCAG 2.1 AA criteria, axe-core testing, CLI NO_COLOR rule, babel/zoneinfo/gettext i18n standards, scope exceptions. |
 | 2026-05-15 | §14: Performance Standards filled — latency targets, memory limits, approved profiling tools, caching libraries, regression escalation criteria. |
 | 2026-05-15 | §16: Data Privacy and Compliance filled — classification levels, PII handling, anonymization, retention/deletion policy, audit trail schema, GDPR/CCPA/HIPAA obligations. |
 | 2026-05-14 | §8: pre-commit hook requirement made mandatory; reference to `skills/secret-scanning.md` and `templates/.pre-commit-config.yaml` added. Remediation steps expanded. |

--- a/skills/api-integration.md
+++ b/skills/api-integration.md
@@ -347,6 +347,97 @@ def test_get_raises_on_404(httpx_mock: HTTPXMock) -> None:
 
 ---
 
+## Rate Limiting and 429/503 Handling
+
+When a server responds with `429 Too Many Requests` or `503 Service Unavailable`,
+the client must back off before retrying. Never retry immediately on these codes.
+
+```python
+import time
+import httpx
+from tenacity import (
+    retry,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential,
+    before_sleep_log,
+)
+import logging
+
+logger = logging.getLogger(__name__)
+
+RATE_LIMITED = {429, 503}
+
+
+def _is_retryable(exc: BaseException) -> bool:
+    """Retry on network errors and rate-limit/unavailable HTTP responses."""
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code in RATE_LIMITED
+    return isinstance(exc, (httpx.TimeoutException, httpx.NetworkError))
+
+
+def _get_retry_after(exc: BaseException) -> float:
+    """Honor Retry-After header when present; default to 60 s."""
+    if isinstance(exc, httpx.HTTPStatusError):
+        header = exc.response.headers.get("Retry-After")
+        if header:
+            return float(header)
+    return 60.0
+
+
+@retry(
+    retry=retry_if_exception(_is_retryable),
+    wait=wait_exponential(multiplier=2, min=4, max=120),
+    stop=stop_after_attempt(6),
+    before_sleep=before_sleep_log(logger, logging.WARNING),
+    reraise=True,
+)
+def get_with_rate_limit(client: httpx.Client, url: str) -> dict:
+    """GET a URL, respecting rate-limit and unavailability responses.
+
+    Args:
+        client: An open httpx.Client instance.
+        url: The URL to fetch.
+
+    Returns:
+        Parsed JSON response.
+
+    Raises:
+        httpx.HTTPStatusError: On non-retryable 4xx/5xx after all attempts.
+    """
+    try:
+        response = client.get(url)
+        response.raise_for_status()
+        return response.json()
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code in RATE_LIMITED:
+            sleep_for = _get_retry_after(exc)
+            logger.warning(
+                "Rate limited; sleeping before retry",
+                status=exc.response.status_code,
+                retry_after=sleep_for,
+            )
+            time.sleep(sleep_for)
+        raise
+```
+
+### Rate-Limit Rules
+
+| HTTP status | Meaning | Required behavior |
+|-------------|---------|------------------|
+| `429` | Too Many Requests | Back off; honor `Retry-After` header if present |
+| `503` | Service Unavailable | Back off with exponential delay; retry up to 6 times |
+| `504` | Gateway Timeout | Treat as transient; retry with backoff |
+| `4xx` (other) | Client error | Do not retry; raise immediately |
+| `5xx` (other) | Server error | Retry with backoff up to 3 times |
+
+- Always read the `Retry-After` header before deciding sleep duration.
+- Maximum backoff cap: 120 seconds per attempt.
+- Log every retry at `WARNING` level with the status code and sleep duration.
+- After all attempts exhausted, raise the original exception — do not swallow it.
+
+---
+
 ## Authentication Methods Reference
 
 | Method | Implementation |

--- a/skills/cloud-cost-management.md
+++ b/skills/cloud-cost-management.md
@@ -1,0 +1,144 @@
+# Skill: Cloud Resource Cost Management
+
+Guidelines for managing cloud compute, storage, and service costs for
+agent-based deployments. Any infrastructure-touching PR must include a
+cost-review section in the PR description.
+
+---
+
+## Tagging Conventions
+
+All cloud resources must be tagged at creation. These tags enable cost
+attribution by workload, owner, and environment.
+
+### Required Tags
+
+| Tag key | Values | Purpose |
+|---------|--------|---------|
+| `project` | `<repo-slug>` | Top-level cost grouping |
+| `env` | `development` · `staging` · `production` | Per-environment cost split |
+| `owner` | GitHub username or team slug | Accountability |
+| `workload` | `api` · `batch` · `etl` · `cli` · `infra` | Workload type for right-sizing |
+| `cost-center` | `<department or project code>` | Finance attribution |
+
+Add tags at resource creation — retrofitting tags is error-prone and misses
+historical spend.
+
+### Terraform/IaC Example
+
+```hcl
+locals {
+  common_tags = {
+    project     = "agents-and-skills"
+    env         = var.environment
+    owner       = "ncarsner"
+    workload    = "api"
+    cost-center = "engineering"
+  }
+}
+
+resource "aws_instance" "app" {
+  # ...
+  tags = local.common_tags
+}
+```
+
+---
+
+## Automated Budget Alerts
+
+Set budget alerts before deploying to staging or production. Never rely on
+manual review to catch cost overruns.
+
+### Alert Thresholds
+
+| Alert type | Threshold | Notification |
+|-----------|-----------|-------------|
+| Monthly actual spend | 80% of budget | Email + Slack `#infra-alerts` |
+| Monthly actual spend | 100% of budget | Email + Slack + open GitHub issue |
+| Daily spike | > 2× 7-day average | Email + open GitHub issue |
+| Forecasted monthly | > 120% of budget | Email + Slack |
+
+### AWS Budgets (CLI setup)
+
+```bash
+aws budgets create-budget \
+  --account-id <account-id> \
+  --budget '{
+    "BudgetName": "<project>-<env>-monthly",
+    "BudgetLimit": {"Amount": "200", "Unit": "USD"},
+    "TimeUnit": "MONTHLY",
+    "BudgetType": "COST",
+    "CostFilters": {"TagKeyValue": ["project$<project-slug>"]}
+  }' \
+  --notifications-with-subscribers '[{
+    "Notification": {
+      "NotificationType": "ACTUAL",
+      "ComparisonOperator": "GREATER_THAN",
+      "Threshold": 80,
+      "ThresholdType": "PERCENTAGE"
+    },
+    "Subscribers": [{"SubscriptionType": "EMAIL", "Address": "<owner-email>"}]
+  }]'
+```
+
+---
+
+## Right-Sizing Recommendations
+
+### Compute (EC2 / Cloud Run / ECS)
+
+| Workload | Starting size | Scale trigger | Notes |
+|----------|-------------|--------------|-------|
+| API service (FastAPI/Flask) | 0.5 vCPU · 512 MB | p95 CPU > 70% for 5 min | Use autoscaling; never over-provision |
+| Batch ETL job | 1 vCPU · 1 GB per worker | Job duration > 2× budget | Prefer spot/preemptible instances |
+| CLI tool (one-shot) | 0.25 vCPU · 256 MB | N/A (ephemeral) | Use serverless (Lambda, Cloud Run jobs) |
+| NLP/ML inference | 2 vCPU · 4 GB | p95 latency > 500 ms | Evaluate GPU only after CPU profiling |
+
+### Storage
+
+| Storage type | Use case | Cost control |
+|-------------|---------|-------------|
+| Object storage (S3, GCS) | Raw data, backups, reports | Lifecycle rules: move to IA after 30 days, Glacier after 90 days |
+| Relational DB (RDS, Cloud SQL) | Transactional data | Use db.t3.micro for dev; reserved instances for production |
+| Managed cache (ElastiCache) | Session cache, rate-limit counters | Eviction policy: `allkeys-lru`; size to fit working set |
+
+Enable storage lifecycle rules at bucket/volume creation — do not add them later.
+
+---
+
+## Cost-Review Checklist (Required in Infrastructure PRs)
+
+Every PR that creates, modifies, or deletes cloud resources must include this
+section in the PR description:
+
+```markdown
+## Cost Review
+
+- [ ] New resources tagged with all required tags (project, env, owner, workload, cost-center)
+- [ ] Monthly cost estimate added below
+- [ ] Budget alert configured (or existing alert covers this resource)
+- [ ] Storage lifecycle rules set (if applicable)
+- [ ] Instance size justified against right-sizing table
+- [ ] Spot/preemptible instances used for batch workloads where possible
+- [ ] No resources left running in development after testing is complete
+
+### Estimated Monthly Cost
+
+| Resource | Size | Estimated cost/month |
+|----------|------|---------------------|
+| | | |
+| **Total** | | **$X.XX** |
+
+Cost estimated using: [AWS Pricing Calculator](https://calculator.aws) /
+[GCP Pricing Calculator](https://cloud.google.com/products/calculator) /
+[Azure Pricing Calculator](https://azure.microsoft.com/pricing/calculator/).
+```
+
+---
+
+## See Also
+
+- [`skills/containerization.md`](containerization.md) — right-sizing in Docker/Kubernetes context
+- [`skills/cost-management.md`](cost-management.md) — LLM API token cost tracking
+- [`RULES.md §17`](../RULES.md#17-deployment-and-environment-parity) — deployment standards

--- a/skills/infrastructure-operations.md
+++ b/skills/infrastructure-operations.md
@@ -1,0 +1,154 @@
+# Skill: Infrastructure and Operations
+
+Patterns for feature flags, canary/blue-green deployment validation, and
+operational conventions for agent-built services.
+
+---
+
+## Feature Flags
+
+Feature flags allow incomplete or experimental features to ship behind a gate,
+decoupling deployment from release.
+
+### Approved Approaches
+
+| Approach | When to use | Implementation |
+|----------|------------|---------------|
+| Environment variable | Simple on/off for a single env | `os.getenv("ENABLE_NEW_FEATURE", "false") == "true"` |
+| `flagsmith` | Multi-environment, user-segment flags | `uv add flagsmith` |
+| `launchdarkly` | Enterprise; real-time flag updates | `uv add launchdarkly-server-sdk` |
+
+Default to the **environment variable approach** for agent-generated code unless
+the project has already adopted a flag management service.
+
+### Environment Variable Pattern
+
+```python
+import os
+
+
+def feature_enabled(flag: str, default: bool = False) -> bool:
+    """Return True if the named feature flag is enabled.
+
+    Args:
+        flag: Environment variable name (e.g. "ENABLE_NEW_PARSER").
+        default: Value when the variable is unset.
+
+    Returns:
+        True when the flag is explicitly set to "true" or "1".
+    """
+    val = os.getenv(flag, "").strip().lower()
+    if not val:
+        return default
+    return val in {"true", "1", "yes"}
+```
+
+```python
+# Usage
+if feature_enabled("ENABLE_NEW_PARSER"):
+    result = new_parser(data)
+else:
+    result = legacy_parser(data)
+```
+
+### Flag Lifecycle Rules
+
+- Every flag must have a declared **owner** (person or team) and a **removal date**
+  in a comment adjacent to its usage:
+  ```python
+  # FLAG: ENABLE_NEW_PARSER — owner: @ncarsner — remove after: 2026-08-01
+  if feature_enabled("ENABLE_NEW_PARSER"):
+  ```
+- Flags older than their removal date are stale and must be cleaned up in the next
+  sprint. The default behavior (feature fully on or fully off) must be committed
+  before the flag is deleted.
+- Never nest feature flags more than one level deep.
+- Do not use feature flags to hide broken code indefinitely — flags are not a
+  substitute for fixing the underlying issue.
+
+---
+
+## Canary and Blue/Green Deployment Validation
+
+`RULES.md §17` defines the blue/green deployment procedure. This section defines
+the **success metrics agents must validate** before a full cutover and the
+**rollback decision rules**.
+
+### Pre-Cutover Smoke Tests
+
+Run against the green environment before switching the load balancer:
+
+```bash
+# 1. Liveness — process is running
+curl -sf http://<green-host>/health | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+assert d['status'] == 'ok', f'health check failed: {d}'
+print('liveness OK')
+"
+
+# 2. Readiness — dependencies reachable
+curl -sf http://<green-host>/ready | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+assert d['status'] == 'ready', f'readiness failed: {d}'
+print('readiness OK')
+"
+
+# 3. Synthetic critical-path request
+curl -sf -X POST http://<green-host>/api/v1/items/ \
+  -H "Content-Type: application/json" \
+  -d '{"name": "smoke-test", "value": 1.0}' | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+assert 'id' in d, f'unexpected response: {d}'
+print('critical path OK')
+"
+```
+
+All three must pass before the load balancer switches. If any fails: abort
+cutover, leave blue active, open an incident.
+
+### Success Metrics for Full Cutover
+
+Monitor these for **at least 5 minutes** after switching traffic to green:
+
+| Metric | Threshold | Action on breach |
+|--------|-----------|-----------------|
+| HTTP 5xx error rate | ≤ 1% of requests | Immediate rollback to blue |
+| p95 response latency | ≤ 200 ms (or project target) | Immediate rollback to blue |
+| Unhandled exception rate | 0 new exception types | Investigate; rollback if persistent |
+| Database connection errors | 0 | Immediate rollback to blue |
+
+### Rollback Procedure
+
+```bash
+# 1. Switch load balancer back to blue (exact command depends on infra)
+# AWS ALB example:
+aws elbv2 modify-listener \
+  --listener-arn <listener-arn> \
+  --default-actions Type=forward,TargetGroupArn=<blue-target-group-arn>
+
+# 2. Verify blue is serving traffic
+curl -sf http://<blue-host>/health
+
+# 3. Open incident issue
+gh issue create \
+  --title "Rollback: <service> vX.Y.Z — <date>" \
+  --body "Rolled back from green (vX.Y.Z) to blue (vX.Y.Z-1). Trigger: <metric that breached>."
+
+# 4. Keep green running for post-mortem analysis — do not tear it down yet
+```
+
+Agents must not trigger a rollback without logging the triggering metric and
+opening a GitHub issue. Human approval is required before any force-push or
+database migration rollback.
+
+---
+
+## See Also
+
+- [`RULES.md §17`](../RULES.md#17-deployment-and-environment-parity) — deployment standards
+- [`skills/containerization.md`](containerization.md) — Docker and health check setup
+- [`skills/web-development.md`](web-development.md) — `/health` and `/ready` endpoint pattern
+- [`skills/secret-scanning.md`](secret-scanning.md) — credential rotation

--- a/skills/secret-scanning.md
+++ b/skills/secret-scanning.md
@@ -154,3 +154,91 @@ git push --force-with-lease
 5. **Audit access logs** — determine whether the exposed credential was used.
 
 6. **Document the incident** — add a timestamped entry to the project's incident log or PR.
+
+---
+
+## Credential Rotation Scheduling
+
+Agents must alert when credentials are approaching expiration and must never
+silently allow an expired credential to remain in use.
+
+### Rotation Schedule Defaults
+
+| Credential type | Maximum lifetime | Alert at |
+|----------------|-----------------|---------|
+| API tokens (third-party services) | 90 days | 14 days before expiry |
+| Database passwords | 180 days | 30 days before expiry |
+| PyPI tokens | 365 days | 30 days before expiry |
+| CI/CD secrets (GitHub Actions) | 365 days | 30 days before expiry |
+| SSH deploy keys | 365 days | 30 days before expiry |
+| TLS certificates | Per CA (≤ 398 days) | 30 days before expiry |
+
+Override defaults in the project's `AGENTS.md` with a written rationale.
+
+### Detecting Expiry
+
+Where the credential provider exposes an expiry date, record it in a
+`.credential-manifest.json` at project root (never committed — add to `.gitignore`):
+
+```json
+{
+  "credentials": [
+    {
+      "name": "THIRD_PARTY_API_TOKEN",
+      "env_var": "THIRD_PARTY_API_TOKEN",
+      "issued": "2026-01-15",
+      "expires": "2026-04-15",
+      "rotation_alert_days": 14
+    }
+  ]
+}
+```
+
+Check expiry programmatically:
+
+```python
+import json
+from datetime import date, timedelta
+from pathlib import Path
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def check_credential_expiry(manifest_path: Path = Path(".credential-manifest.json")) -> None:
+    """Log warnings for credentials approaching expiration.
+
+    Raises:
+        RuntimeError: If any credential is already expired.
+    """
+    if not manifest_path.exists():
+        return
+    manifest = json.loads(manifest_path.read_text())
+    today = date.today()
+    for cred in manifest.get("credentials", []):
+        expires = date.fromisoformat(cred["expires"])
+        alert_at = expires - timedelta(days=cred.get("rotation_alert_days", 14))
+        if today >= expires:
+            raise RuntimeError(
+                f"Credential '{cred['name']}' expired on {expires}. Rotate immediately."
+            )
+        if today >= alert_at:
+            logger.warning(
+                "Credential approaching expiration",
+                name=cred["name"],
+                expires=str(expires),
+                days_remaining=(expires - today).days,
+            )
+```
+
+Call `check_credential_expiry()` at application startup and as a CI step.
+
+### Rotation Procedure
+
+1. Generate the new credential in the provider's console.
+2. Update the secret in all environments (GitHub Actions secrets, `.env` on each host).
+3. Verify the application starts cleanly with the new credential.
+4. Revoke the old credential in the provider's console.
+5. Update `expires` in `.credential-manifest.json` and commit the manifest file update
+   (the manifest file itself is gitignored; commit only the `.gitignore` entry).
+6. Log the rotation in the project's incident/maintenance log.

--- a/skills/skills.md
+++ b/skills/skills.md
@@ -23,11 +23,13 @@ recipes, and code cookbooks. They are read on demand when an agent needs to know
 | [`logging-observability.md`](logging-observability.md) | All | structlog, logging levels, audit trails |
 | [`configuration-management.md`](configuration-management.md) | All | Config file handling patterns |
 | [`github-issue-creation.md`](github-issue-creation.md) | All | GitHub issue authorization rules and `gh` commands |
-| [`secret-scanning.md`](secret-scanning.md) | All | Pre-commit hook setup, baseline management, incident remediation |
+| [`secret-scanning.md`](secret-scanning.md) | All | Pre-commit hook setup, baseline management, credential rotation, incident remediation |
 | [`multi-agent.md`](multi-agent.md) | All | Handoff payload schema, context passing, loop detection, logging |
 | [`prompt-engineering.md`](prompt-engineering.md) | All | Prompt structure standards, injection defense, token efficiency |
 | [`cost-management.md`](cost-management.md) | All | LLM token logging, session budget guards, pre-flight cost estimation |
 | [`containerization.md`](containerization.md) | DevOps | Docker multi-stage builds, non-root user, .dockerignore, trivy scanning |
+| [`infrastructure-operations.md`](infrastructure-operations.md) | DevOps | Feature flags, canary/blue-green validation, rollback procedure |
+| [`cloud-cost-management.md`](cloud-cost-management.md) | DevOps | Resource tagging, budget alerts, right-sizing, cost-review checklist |
 | [`cli-development.md`](cli-development.md) | CLI | Click/Typer patterns, terminal UI |
 | [`web-development.md`](web-development.md) | Web | FastAPI, Flask, Django patterns |
 | [`api-integration.md`](api-integration.md) | Data/Web | HTTP clients, retry, pagination |

--- a/skills/web-development.md
+++ b/skills/web-development.md
@@ -359,6 +359,83 @@ def test_create_item_validates_name(client: TestClient) -> None:
 
 ---
 
+## Health Check Convention
+
+Every containerized web service must expose `/health` (liveness) and
+`/ready` (readiness) endpoints. These are required for Kubernetes probes,
+Docker health checks, and load-balancer routing.
+
+```python
+from fastapi import FastAPI, status
+from pydantic import BaseModel
+
+
+class HealthResponse(BaseModel):
+    """Standard health check response."""
+    status: str
+    version: str
+
+
+def register_health_routes(app: FastAPI, version: str) -> None:
+    """Attach /health and /ready to app."""
+
+    @app.get("/health", response_model=HealthResponse, tags=["ops"])
+    def liveness() -> HealthResponse:
+        """Liveness probe — returns 200 when the process is running."""
+        return HealthResponse(status="ok", version=version)
+
+    @app.get("/ready", response_model=HealthResponse, tags=["ops"])
+    def readiness(db: bool = True) -> HealthResponse:
+        """Readiness probe — returns 200 only when dependencies are reachable.
+
+        Raises:
+            HTTPException 503: When a required dependency is unavailable.
+        """
+        from fastapi import HTTPException
+        if not _check_db():
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="database unavailable",
+            )
+        return HealthResponse(status="ready", version=version)
+
+
+def _check_db() -> bool:
+    """Return True if the database responds to a lightweight query."""
+    try:
+        # Replace with an actual DB ping appropriate for your ORM/driver
+        from sqlalchemy import text
+        from my_api.database import engine
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+        return True
+    except Exception:
+        return False
+```
+
+### Probe Rules
+
+| Endpoint | Probe type | Returns 200 when | Returns 503 when |
+|----------|-----------|-----------------|-----------------|
+| `/health` | Liveness | Process is alive | Never (if process is alive) |
+| `/ready` | Readiness | All dependencies reachable | Any dependency down |
+
+- Both endpoints must respond in < 200 ms.
+- `/health` must never call external services — it only proves the process is running.
+- `/ready` must check every dependency the service needs to serve traffic (DB, cache, upstream APIs).
+- Exclude `/health` and `/ready` from authentication middleware.
+- In Docker Compose, declare as:
+  ```yaml
+  healthcheck:
+    test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+    interval: 30s
+    timeout: 5s
+    retries: 3
+    start_period: 10s
+  ```
+
+---
+
 ## See Also
 
 - [`agents/web-dev-agent.md`](../agents/web-dev-agent.md)

--- a/subagents/project-review-interoperability.md
+++ b/subagents/project-review-interoperability.md
@@ -73,7 +73,7 @@ CONTRACT COMPLIANCE:
   Contract tests present: <yes | no | not required>
 
 VERSIONING:
-  Current version: <semver or "unversioned">
+  Current version: <semantic version or "unversioned">
   Required bump: <major | minor | patch | none>
   Version bump applied: <yes | no | not required>
 

--- a/subagents/registry.json
+++ b/subagents/registry.json
@@ -206,7 +206,7 @@
       "domain": "publishing",
       "version": "1.0.0",
       "status": "active",
-      "role": "Manage PyPI package releases: semver, CHANGELOG, build, publish, GitHub Release",
+      "role": "Manage PyPI package releases: semantic versioning, CHANGELOG, build, publish, GitHub Release",
       "skills_used": ["python-uv-workflow", "secret-scanning", "python-testing"]
     }
   ],

--- a/subagents/registry.json
+++ b/subagents/registry.json
@@ -199,6 +199,15 @@
       "status": "active",
       "role": "Audit and implement data collection pipelines: provenance, quality, PII, compliance",
       "skills_used": ["api-integration", "database-access", "python-testing", "logging-observability", "configuration-management"]
+    },
+    {
+      "file": "subagents/release-agent.md",
+      "name": "release-agent",
+      "domain": "publishing",
+      "version": "1.0.0",
+      "status": "active",
+      "role": "Manage PyPI package releases: semver, CHANGELOG, build, publish, GitHub Release",
+      "skills_used": ["python-uv-workflow", "secret-scanning", "python-testing"]
     }
   ],
   "skills": [

--- a/subagents/release-agent.md
+++ b/subagents/release-agent.md
@@ -1,0 +1,189 @@
+# Release Agent Instructions
+
+This file extends `AGENTS.md` with instructions specific to publishing
+**Python packages to PyPI**. Read root `AGENTS.md` and `RULES.md` first.
+
+---
+
+## Purpose
+
+The release agent manages the end-to-end workflow for cutting a versioned
+release: bumping version, updating `CHANGELOG.md`, building and publishing
+the distribution, and tagging the commit. It never bypasses CI gates.
+
+---
+
+## Versioning Policy
+
+Follow [Semantic Versioning 2.0.0](https://semver.org/):
+
+| Change type | Version bump | Example |
+|-------------|-------------|---------|
+| Breaking change to public API | MAJOR | 1.2.3 → 2.0.0 |
+| New backward-compatible feature | MINOR | 1.2.3 → 1.3.0 |
+| Bug fix, patch, or dependency bump | PATCH | 1.2.3 → 1.2.4 |
+
+Rules:
+- Version lives in `pyproject.toml` under `[project] version`.
+- Never set `version = "0.0.0"` in production; start at `0.1.0` for pre-release,
+  `1.0.0` when the public API is stable.
+- Do not use `setuptools-scm` or dynamic versioning unless explicitly authorized.
+- Pre-release identifiers: `1.0.0a1`, `1.0.0b1`, `1.0.0rc1`.
+
+---
+
+## CHANGELOG.md Format
+
+Follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+```markdown
+# Changelog
+
+## [Unreleased]
+
+### Added
+- Short description of new feature.
+
+### Changed
+- Short description of changed behavior.
+
+### Fixed
+- Short description of bug fix.
+
+## [1.2.3] — 2026-05-15
+
+### Fixed
+- Corrected off-by-one error in pagination helper.
+
+[Unreleased]: https://github.com/org/repo/compare/v1.2.3...HEAD
+[1.2.3]: https://github.com/org/repo/compare/v1.2.2...v1.2.3
+```
+
+Rules:
+- Every user-visible change goes in `[Unreleased]` during development.
+- When cutting a release, rename `[Unreleased]` to `[X.Y.Z] — <date>` and add a
+  new empty `[Unreleased]` section above it.
+- Use exactly these subsections: `Added`, `Changed`, `Deprecated`, `Removed`,
+  `Fixed`, `Security`. Do not invent new subsection names.
+- Keep entries short (one sentence). Do not include internal refactors unless they
+  affect public API behavior.
+
+---
+
+## Required CI Gates Before Release
+
+All of the following must pass on the release commit before tagging:
+
+```bash
+pre-commit run --all-files          # secret scanning (RULES.md §8)
+ruff check .                        # no lint errors
+mypy src/                           # no type errors
+python3 -m pytest --cov=src --cov-fail-under=100   # 100% coverage
+pip-audit                           # no known dependency vulnerabilities
+```
+
+A release tag must not be created if any gate fails. No exceptions.
+
+---
+
+## Build and Publish Workflow
+
+### 1. Verify clean working tree
+
+```bash
+git status          # must be clean
+git log --oneline -5
+```
+
+### 2. Bump version in `pyproject.toml`
+
+Edit `[project] version` manually. Then verify the package builds cleanly:
+
+```bash
+uv build
+```
+
+The `dist/` directory must contain both a `.tar.gz` (sdist) and a `.whl` (wheel).
+
+### 3. Update CHANGELOG.md
+
+- Move all items from `[Unreleased]` into the new versioned section.
+- Add comparison links at the bottom.
+- Commit: `chore: release vX.Y.Z`.
+
+### 4. Tag the release
+
+```bash
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git push origin main --tags
+```
+
+### 5. Publish to PyPI
+
+```bash
+uv publish
+```
+
+`uv publish` reads credentials from the environment. Never pass tokens on the
+command line or store them in any file.
+
+#### Credential storage
+
+| Environment | Token source |
+|-------------|-------------|
+| Local dev | `PYPI_TOKEN` env var (set in shell; never in `.env` file) |
+| GitHub Actions | `secrets.PYPI_TOKEN` repository secret |
+
+GitHub Actions publish step:
+
+```yaml
+- name: Publish to PyPI
+  env:
+    UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
+  run: uv publish
+```
+
+Fallback (if `uv publish` is unavailable): `twine upload dist/*` with
+`TWINE_PASSWORD` set from the same secret. Do not use `--skip-existing`.
+
+### 6. Create GitHub Release
+
+```bash
+gh release create vX.Y.Z dist/* \
+  --title "vX.Y.Z" \
+  --notes "$(sed -n '/## \[X.Y.Z\]/,/## \[/p' CHANGELOG.md | head -n -1)"
+```
+
+Attach the `dist/` artifacts to the release.
+
+---
+
+## PyPI Token Security
+
+- Tokens are scoped to a single project — never use an account-wide token.
+- Rotate tokens immediately if exposed. Report via `skills/secret-scanning.md`
+  incident procedure.
+- Store only in GitHub Actions secrets or a local secrets manager (`pass`,
+  `1Password CLI`). Never commit, log, or print.
+
+---
+
+## Pre-release Checklist
+
+- [ ] Version bumped in `pyproject.toml`
+- [ ] `CHANGELOG.md` updated: `[Unreleased]` → `[X.Y.Z] — <date>`
+- [ ] All CI gates pass on the release commit
+- [ ] `uv build` produces `.whl` and `.tar.gz` without errors
+- [ ] `git tag vX.Y.Z` created and pushed
+- [ ] `uv publish` succeeded; package visible on PyPI within 5 minutes
+- [ ] GitHub Release created with `dist/` artifacts attached
+- [ ] New empty `[Unreleased]` section added to `CHANGELOG.md`
+
+---
+
+## See Also
+
+- [`RULES.md §7`](../RULES.md#7-testing-and-coverage) — 100% coverage gate
+- [`RULES.md §8`](../RULES.md#8-security-and-secrets) — secret scanning before release
+- [`skills/python-uv-workflow.md`](../skills/python-uv-workflow.md) — `uv` package manager reference
+- [`skills/secret-scanning.md`](../skills/secret-scanning.md) — token incident response

--- a/subagents/subagents.md
+++ b/subagents/subagents.md
@@ -233,6 +233,7 @@ modified to a new MINOR/MAJOR version, deprecated, or removed.
 | [`project-review-interoperability.md`](project-review-interoperability.md) | Ad hoc review: API contracts, protocol correctness, and integration compatibility |
 | [`project-review-observability.md`](project-review-observability.md) | Ad hoc review: logging, metrics, tracing, and audit log coverage |
 | [`data-collection-agent.md`](data-collection-agent.md) | Audit and implement data collection pipelines: provenance, quality, PII, compliance |
+| [`release-agent.md`](release-agent.md) | Manage PyPI package releases: semver, CHANGELOG, build, publish, GitHub Release |
 
 ---
 

--- a/subagents/subagents.md
+++ b/subagents/subagents.md
@@ -233,7 +233,7 @@ modified to a new MINOR/MAJOR version, deprecated, or removed.
 | [`project-review-interoperability.md`](project-review-interoperability.md) | Ad hoc review: API contracts, protocol correctness, and integration compatibility |
 | [`project-review-observability.md`](project-review-observability.md) | Ad hoc review: logging, metrics, tracing, and audit log coverage |
 | [`data-collection-agent.md`](data-collection-agent.md) | Audit and implement data collection pipelines: provenance, quality, PII, compliance |
-| [`release-agent.md`](release-agent.md) | Manage PyPI package releases: semver, CHANGELOG, build, publish, GitHub Release |
+| [`release-agent.md`](release-agent.md) | Manage PyPI package releases: semantic versioning, CHANGELOG, build, publish, GitHub Release |
 
 ---
 


### PR DESCRIPTION
## Summary

**Closes #26 — Composite: Infrastructure & Operations Gaps**

Five sub-items addressed:

- **Rate limiting/backoff** (`skills/api-integration.md`): `_is_retryable` / `_get_retry_after` helpers, `@retry` decorator honoring `Retry-After` header, per-status rules table (429/503/504 back off; other 4xx raise immediately; max cap 120 s)
- **Health checks** (`skills/web-development.md`): `/health` (liveness) and `/ready` (readiness) FastAPI pattern with `_check_db()` helper, probe rules table, Docker Compose `healthcheck` stanza
- **Secrets rotation scheduling** (`skills/secret-scanning.md`): rotation schedule by credential type, `.credential-manifest.json` pattern, `check_credential_expiry()` startup helper, 6-step rotation procedure
- **Feature flags** (`skills/infrastructure-operations.md` — new): env-var default pattern, `flagsmith`/`launchdarkly` as approved alternatives, flag lifecycle rules (owner + removal date required)
- **Canary/blue-green success metrics** (`skills/infrastructure-operations.md`): pre-cutover smoke test scripts, success metrics table (5xx ≤ 1%, p95 ≤ 200 ms, 0 new exception types), rollback procedure with `gh issue create` step

**Closes #18 — Cloud Resource Cost Management**

- `skills/cloud-cost-management.md` (new): 5 required resource tags, budget alert thresholds (80%/100%/daily-spike/forecast), right-sizing table by workload (API, batch, CLI, NLP/ML), storage lifecycle rules, cost-review PR checklist template with estimated-cost table

**Housekeeping:** replaced `semver` → `semantic versioning` across `CHANGELOG.md`, `subagents/registry.json`, `subagents/subagents.md`, `subagents/project-review-interoperability.md`.

## Test plan
- [ ] `skills/api-integration.md` has Rate Limiting section with 429/503 rules table
- [ ] `skills/web-development.md` has Health Check Convention with `/health` + `/ready` pattern
- [ ] `skills/secret-scanning.md` has Credential Rotation Scheduling section
- [ ] `skills/infrastructure-operations.md` exists with feature flags and blue/green sections
- [ ] `skills/cloud-cost-management.md` exists with tagging, alerts, right-sizing, checklist
- [ ] `skills/skills.md` lists the two new skill files
- [ ] No remaining `semver` in live doc files (excluding `approved-packages.md` package name and `_SCRIPTS/` historical text)