### PR TITLE
docs: Karpathy wiki lens — extend 12-factor analysis and document worktree patterns

### DIFF
--- a/.12-FACTOR-AGENTS.md
+++ b/.12-FACTOR-AGENTS.md
@@ -1,0 +1,195 @@
+# 12-Factor Agents — Analysis vs. Current Orchestration
+
+Source: https://github.com/humanlayer/12-factor-agents  
+Compared against: `CLAUDE.md`, `RULES.md`, `STRATEGY.md`, `README.md`  
+Date: 2026-05-17
+
+---
+
+## Summary
+
+Repo aligns well on **prompt ownership, control flow, and specialist decomposition** (F1, F2, F8, F10). Critical gaps: no unified execution+business state model (F5), no self-healing error retry loop (F9), no multi-channel trigger support (F11). Partial coverage on context optimization, structured outputs, pause/resume, and human-contact protocol. Adopting missing factors would harden `ralph.sh` loops and reduce agent spin-out risk; tradeoff is added architectural complexity and JSON-discipline overhead for a currently docs-first repo.
+
+---
+
+## Factor-by-Factor Analysis
+
+| # | Factor | Status | Where covered | Gap |
+|---|--------|--------|--------------|-----|
+| 1 | NL → Tool Calls | ✅ | `CLAUDE.md` CLI agents table; subagents delegate to deterministic CLI | None — pattern is established |
+| 2 | Own Your Prompts | ✅ | `RULES.md §13`; `skills/` docs are explicit, versioned prompt context | None — skills/ acts as prompt library |
+| 3 | Own Your Context Window | ⚠️ | `STRATEGY.md §3` skills caching, session scoping | No token-density optimization; no custom XML/structured context formats; context budget is time-based not token-based |
+| 4 | Tools = Structured Outputs | ⚠️ | `subagents/subagents.md` defines delegation protocol | No JSON output schema discipline; tool calls are prose prompts not typed structured outputs |
+| 5 | Unify Execution + Business State | ❌ | Session summaries capture business state; `ralph.sh` tracks task state separately | Two sources of truth — `*-progress.txt` + session summaries; no unified state model; hard to fork/replay/debug |
+| 6 | Launch / Pause / Resume | ⚠️ | `ralph.sh --prd` iterates with commit-based checkpoints | No webhook resume; no external API; pause is implicit (loop exits, human re-runs); no introspectable agent status |
+| 7 | Contact Humans via Tool Calls | ⚠️ | `RULES.md §13` mandates escalation to human for ambiguous/destructive actions | No structured human-contact tool (no `RequestHumanInput` schema); escalation is prose instruction not typed protocol |
+| 8 | Own Your Control Flow | ✅ | `ralph.sh` owns the loop; `RULES.md §13` defines escalation triggers; `STRATEGY.md` defines session boundaries | None — control flow is explicit and customizable |
+| 9 | Compact Errors into Context | ❌ | `RULES.md §9` defines error handling patterns for Python code | No agent-level error counter; no retry-with-error-in-context loop; ralph loop does not compact failures back into model context |
+| 10 | Small, Focused Agents | ✅ | `subagents/` roster is specialized by domain; `STRATEGY.md §2` one-specialist-per-task | None — decomposition discipline is strong |
+| 11 | Trigger from Anywhere | ❌ | CLI only (`claude -p`, `gemini -p`, `codex exec`) | No Slack/email/webhook triggers; no outer-loop agent pattern; agents are human-initiated only |
+| 12 | Stateless Reducer | ⚠️ | Session summaries approximate state handoff; each session reads prior summary and produces new one | No formal reducer model; state is prose in markdown, not serializable structured data; no fork/replay |
+| 13 | Pre-fetch Context (Appendix) | ⚠️ | `STRATEGY.md §3` attaches skills docs at session start | Pre-fetch is manual and human-directed; no deterministic "if model will call X, fetch X first" automation |
+
+---
+
+## Key Benefits of Adopting Missing Factors
+
+**F5 — Unified state model**  
+Single source of truth for task + execution state → simpler debugging, replay, and agent handoff. `ralph.sh` progress files + session summaries would merge into one auditable record.
+
+**F9 — Error self-healing loop**  
+Compact errors into context + retry counter → agents recover from transient failures without human intervention. Directly reduces `ralph.sh` spin-out risk on flaky tool calls.
+
+**F7 — Structured human-contact protocol**  
+Typed `RequestHumanInput` tool call → human escalations are machine-readable, auditable, resumable. Current prose escalation (`RULES.md §13`) can't be programmatically detected or acted on by an outer agent.
+
+**F3 — Context window optimization**  
+Token-density discipline + custom context formats → more task content fits per window → fewer context truncation failures in long `ralph.sh` loops.
+
+**F12 — Stateless reducer**  
+Serializable structured state → agent sessions become forkable, testable, and introspectable. Session summaries in markdown are human-readable but not machine-resumable.
+
+---
+
+## Key Tradeoffs
+
+| Tradeoff | Detail |
+|----------|--------|
+| Complexity vs. control | F4/F5/F12 require JSON schema discipline across all subagents — high overhead for a docs-first repo with prose-driven agents |
+| Structured outputs lock-in | Typed tool schemas couple subagents to a specific output contract; current prose prompts are easier to iterate |
+| F11 trigger infrastructure | Multi-channel triggers require webhook endpoints, auth, and event routing — significant infra investment for a local CLI-first workflow |
+| F6 webhook resume | True pause/resume needs durable state storage outside the process; `ralph.sh` commit-based checkpointing is simpler and fits the current no-server model |
+| F9 retry loops | Error-compaction loops risk agent spin-out if error is not transient; needs `small focused agents` (F10) to bound blast radius — already satisfied here |
+| Docs-first tension | Repo is primarily a reference library, not a deployed agent runtime. F6, F11, F12 are most valuable for production agent services; partial benefit for a template/reference repo |
+
+---
+
+## Recommendations (ranked by impact/effort ratio)
+
+1. **F9 — Add error-compact retry to `ralph.sh`** (high impact, low effort)  
+   Add error counter (max 3), append tool errors to context on retry, break loop and escalate on threshold. Pure shell/prompt change — no infra needed.
+
+2. **F7 — Define structured human-contact protocol** (high impact, medium effort)  
+   Add `RequestHumanInput` schema to `subagents/subagents.md`. Update `RULES.md §13` escalation rule to emit typed JSON instead of prose. Enables future programmatic handling.
+
+3. **F5 — Unify state in `ralph.sh --prd` mode** (medium impact, medium effort)  
+   Merge `*-progress.txt` and session summary into one structured JSON state file. Enables replay, fork, and cleaner handoff between sessions.
+
+4. **F3 — Add token-budget guidance to `STRATEGY.md`** (medium impact, low effort)  
+   Extend `STRATEGY.md §3` with token-density rules: max context budget per session tier, guidance on custom context formats, when to truncate vs. summarize history.
+
+5. **F13 — Pre-fetch pattern in `subagents/subagents.md`** (medium impact, low effort)  
+   Add a pre-fetch protocol: list tools likely needed per subagent type; call deterministically at session start before model invocation.
+
+6. **F12 — Structured state schema** (low impact now, high future value)  
+   Define a JSON schema for session state in `templates/`. Low urgency while repo is docs-only; critical if agents become deployed services.
+
+7. **F11 — Multi-channel triggers** (low impact for reference repo, high for productization)  
+   Defer. Only relevant if this repo's agent patterns are productized into a running service. Document as future work in `STRATEGY.md`.
+
+---
+
+## Karpathy Wiki Lens — Persistent Context as Session Efficiency
+
+Source: [LLM Wiki gist](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)  
+Cross-referenced against: `STRATEGY.md`, existing factor gaps (F3, F5, F12, F13)
+
+### Core Idea
+
+Instead of re-synthesizing knowledge at every session start, maintain a persistent, compounding wiki that agents incrementally update. Three primitives:
+
+- **`index.md`** — content-oriented catalog with one-line summaries per page; agents query before acting
+- **`log.md`** — append-only chronological record of operations, decisions, and errors
+- **Wiki pages** — LLM-generated summaries and cross-references, updated as sources and sessions arrive
+
+Human role: source curation, strategic direction. Agent role: bookkeeping, summarizing, consistency.
+
+---
+
+### Mapping to Existing Repo Artifacts
+
+| Karpathy primitive | Current equivalent | Gap |
+|---|---|---|
+| `index.md` (content catalog) | `CLAUDE.md` "On-demand resources" table | Table exists; no query convention, no update protocol, not linked from subagent prompts |
+| `log.md` (append-only record) | `plans/*-progress.txt` + session summaries | Fragmented — two artifacts, neither append-only by convention |
+| Wiki pages (synthesized summaries) | `skills/` docs + phase summaries | Strong for skill patterns; session summaries are ad hoc and unindexed |
+| Lint operation (health-check) | None | Gap — no periodic audit for stale claims across `skills/`, `subagents/`, or summaries |
+| Schema / config | `CLAUDE.md` | Fully covered — schema role already established |
+
+The key insight: **`CLAUDE.md`'s on-demand table is a proto-Karpathy `index.md`**. Formalizing it — adding a query convention, one-line content hooks, and an update protocol — closes F13 without new infrastructure and without changing how agents already work.
+
+---
+
+### Where Wiki Primitives Resolve 12-Factor Gaps
+
+**F3 — Context Window Optimization**
+
+Karpathy's wiki delivers pre-synthesized, high-density context rather than raw source documents. `skills/` already does this for patterns. The remaining gap is session state: agents receive raw prior summaries instead of pre-filtered, indexed pages. Fix: query `index.md` first at session open; load only task-relevant pages. `STRATEGY.md §1` already mandates "read `Next Steps` only" — extend this to index-first lookup before loading any session document.
+
+**F5 — Unified Execution + Business State**
+
+The two-artifact problem (`*-progress.txt` + session summaries) maps directly to the need for a single `log.md`. Concrete position: **`log.md` replaces `*-progress.txt`; structured wiki session pages replace ad-hoc session summaries**. Each `ralph.sh` iteration appends one structured line to `log.md`:
+
+```
+[timestamp] [task_id] [status] [err_count] [one-line summary]
+```
+
+Session outcomes become wiki pages (`sessions/yyyy-mm-dd-phase.md`) indexed in `index.md`. Result: one auditable record with no second source of truth. Adding wiki pages is not a third artifact — it replaces both existing ones.
+
+**F12 — Stateless Reducer**
+
+Karpathy's wiki is structured prose markdown — the same format as current session summaries — augmented with cross-references and an index. This validates the docs-first approach: structured markdown with `index.md` + `log.md` is sufficient as a reducer state store for a reference repo that is not a deployed service. The missing piece is index and cross-reference discipline, not a JSON schema. JSON schema is over-engineering here; defer it to productization (as originally recommended).
+
+**F13 — Pre-fetch Context**
+
+Wiki `index.md` enables deterministic pre-fetch: at session start, grep the index for task-domain keywords; attach matching pages before the first model call. The current `CLAUDE.md` on-demand table is human-directed and manual. Adding one line to `subagents/subagents.md` closes this: "Before invoking a subagent, grep `index.md` for pages relevant to the task domain and include them in the prompt." No infrastructure change required.
+
+---
+
+### Session Efficiency Protocol (Karpathy-Informed)
+
+Combines `STRATEGY.md` session discipline with wiki primitives. Adds ~2 minutes to session open/close; eliminates re-synthesis waste across sessions.
+
+**Session open (≤ 5 minutes total):**
+
+1. Grep `index.md` for pages matching the task domain — load those pages only.
+2. Read `log.md` tail (last 10 entries) — current task status, recent errors, open threads.
+3. Load specialist `skills/` files for the session scope (`STRATEGY.md §3` — unchanged).
+
+**Session work:**
+
+- `ralph.sh` loop appends one structured entry to `log.md` per iteration (timestamp, task ID, status, error count, summary).
+- On tool error: append error to `log.md`; retry with error in context (F9 self-healing loop). Max 3 retries before escalating to human.
+
+**Session close (≤ 10 minutes total):**
+
+1. Write session wiki page: `sessions/yyyy-mm-dd-phase.md` — outcomes, decisions, cross-references to modified `skills/` or `subagents/` files, next-session subagent plan.
+2. Add pointer to `index.md` for new or updated pages.
+3. Commit (`STRATEGY.md §1` closing ritual is unchanged; wiki page replaces the prose summary file).
+
+**Periodic lint (weekly or before a major session):**
+
+- Check `index.md` for orphan pointers (referenced pages that are missing or renamed).
+- Audit `log.md` for unresolved error entries (status never flipped to complete).
+- Flag `skills/` docs with claims referencing tools or versions more than six months old.
+
+---
+
+### Revised Recommendations (Supersede Ranks 3–6)
+
+The following replaces the original recommendations for F3, F5, F12, and F13 with Karpathy-informed alternatives. Ranks 1 and 2 (F9, F7) are unchanged — they remain the highest-impact, lowest-effort changes.
+
+| Rank | Factor | Original recommendation | Karpathy-revised recommendation | What changes |
+|------|--------|------------------------|--------------------------------|--------------|
+| 3 | F5 | Merge `*-progress.txt` + session summary into one structured JSON state file | Replace both with `log.md` (append-only structured text rows) + indexed session wiki pages | Simpler than JSON; fits docs-first repo; aligns F5 with F12 simultaneously |
+| 4 | F3 | Add token-budget guidance to `STRATEGY.md` | Formalize `CLAUDE.md` on-demand table as `index.md` with query conventions and update protocol | Index-first lookup is more actionable than budget numbers; delivers immediate token savings |
+| 5 | F13 | Add a pre-fetch protocol to `subagents/subagents.md` | Add index-query line to `subagents/subagents.md`: "grep `index.md` before first model call" | Same target; more concrete mechanism; zero new infra |
+| 6 | F12 | Define a JSON schema for session state in `templates/` | Adopt wiki-page format (markdown + frontmatter) as session state; `index.md` as reducer catalog | More tractable for docs-first; defer JSON schema to productization phase only |
+
+---
+
+### Additional Tradeoff
+
+| Tradeoff | Detail |
+|----------|--------|
+| Wiki discipline overhead | Maintaining `index.md` and `log.md` requires session-close discipline equivalent to `STRATEGY.md §1`. If the closing ritual is skipped, the wiki drifts. Mitigate by automating `log.md` writes inside `ralph.sh` (per-iteration append) so the execution log stays current even when the session wiki page is missed. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ python3 -m pytest -x
 | New project onboarding | [templates/onboarding-checklist.md](templates/onboarding-checklist.md) |
 | Containerization patterns | [skills/containerization.md](skills/containerization.md) |
 | Session shutdown protocol | [templates/epilogue.md](templates/epilogue.md) |
+| 12-factor agents analysis + Karpathy wiki lens | [.12-FACTOR-AGENTS.md](.12-FACTOR-AGENTS.md) |
 
 ## Changelog
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## 2026-05-17
+
+### Added
+- `.12-FACTOR-AGENTS.md` — analysis of 12-factor agents spec against current repo orchestration, extended with Karpathy wiki lens section mapping `index.md`/`log.md`/wiki-page primitives to existing artifacts and revised recommendations for F3, F5, F12, F13.
+- `_SOLUTIONS/2026-05-17-karpathy-wiki.md` — reference document on git worktree mechanics in this repo: filesystem vs. object-level duplication, benefits/tradeoffs, and five refactoring opportunities (tracked as issues #57–#61).
+
+---
+
 ## 2026-05-15 (batch 3)
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ python3 -m pytest -x
 | Session efficiency strategy | [STRATEGY.md](STRATEGY.md) |
 | Domain-specific profiles (WAT, web design) | [profiles/](profiles/) |
 | Session shutdown protocol | [templates/epilogue.md](templates/epilogue.md) |
+| 12-factor agents analysis + Karpathy wiki lens | [.12-FACTOR-AGENTS.md](.12-FACTOR-AGENTS.md) |
 
 ## Subagent Delegation
 

--- a/_SOLUTIONS/2026-05-17-karpathy-wiki.md
+++ b/_SOLUTIONS/2026-05-17-karpathy-wiki.md
@@ -1,0 +1,124 @@
+# Worktrees in This Repo — Benefits, Tradeoffs, and Refactoring Opportunities
+
+Date: 2026-05-17  
+Context: Background agent isolation via Claude Code harness; Karpathy wiki lens applied to 12-factor analysis
+
+---
+
+## What a Git Worktree Is
+
+A git worktree is a linked working directory that shares a single `.git` object store with a parent repository. Every tracked file is checked out into the worktree's directory, but git objects (commits, blobs, trees) are not duplicated — they live once in the parent's object store. Each worktree must be on a unique branch; the same branch cannot be active in two worktrees simultaneously.
+
+The worktree's root contains a `.git` file (not a directory) that points back to the parent repo's gitdir, plus a full copy of every tracked file on its branch.
+
+---
+
+## How the Claude Code Harness Uses Worktrees
+
+The harness creates worktrees under `.claude/worktrees/<name>/` inside the main repo directory. When a background session starts, the harness calls `EnterWorktree`, which runs `git worktree add` and switches the session's working directory to the new path. The purpose is isolation: changes made by a background agent land on a separate branch and do not pollute the user's main working copy.
+
+This session's worktree lives at:
+
+```
+/Users/carsner/Code/agents-and-skills/.claude/worktrees/12-factor-karpathy-extension/
+```
+
+Branch: `feat-20260517-karpathy-wiki` (renamed from the auto-generated `worktree-12-factor-karpathy-extension`).
+
+---
+
+## Is This Duplication?
+
+**At the git object level: no.** Blobs, trees, and commits are shared. The parent repo's object store is the single source of truth. Creating a worktree does not copy git history.
+
+**At the filesystem level: yes.** Every tracked file on the checked-out branch is copied into the worktree directory. For this repo that means a full copy of `skills/`, `subagents/`, `templates/`, `tools/`, `plans/`, and all root markdown files — the same byte-for-byte content as the main checkout, on the branch the worktree was created from.
+
+**Practical size for this repo:** The repo is docs-first (markdown + shell). No compiled artifacts, no `node_modules`, no `.venv`. A worktree adds roughly the same disk footprint as the main checkout — small (order of magnitude: single-digit MB). Disk duplication is not a problem here.
+
+**The more significant duplication is conceptual.** `skills/`, `subagents/`, and `templates/` are reference libraries. They are read-only from the perspective of most background tasks. Duplicating them into every worktree means:
+
+1. A background agent that improves a `skills/` doc writes the improvement to the worktree copy, which must then be merged back to main before the improvement is visible to future sessions.
+2. If two worktrees both modify the same skills doc, merge conflicts arise even though neither task was logically related to that file.
+
+---
+
+## Benefits of Worktrees for This Repo
+
+**Background agent isolation.** The primary use case. A background agent (e.g., this session) works on a branch without disturbing the user's main working copy. The user can continue editing on `main` while the agent works in the worktree.
+
+**No stash/checkout dance.** Switching context does not require stashing uncommitted work. Main and worktree coexist with independent working directories.
+
+**Parallel branch work.** Multiple worktrees can be active simultaneously on different branches. For a docs repo with several open GitHub issues being worked in parallel, each gets its own isolated directory.
+
+**Lightweight for docs.** No build artifacts to duplicate. Worktree creation is fast and low-cost.
+
+**Harness-native safety.** Claude Code's isolation guard prevents background edits from landing in the user's live checkout without an explicit merge step.
+
+---
+
+## Tradeoffs
+
+| Tradeoff | Detail |
+|----------|--------|
+| Untracked files do not transfer | Files not yet committed to git are invisible to the worktree. This session had to manually copy `.12-FACTOR-AGENTS.md` into the worktree because it was untracked in main. Workflow friction when a task builds on in-progress work. |
+| Nested worktree path | `.claude/worktrees/` is inside the main repo directory. Most git workflows place worktrees as siblings (`../repo-worktree/`), not children. The nested path is non-standard and can confuse tools that walk parent directories looking for `.git`. |
+| `.claude/worktrees/` not in `.gitignore` | Git correctly recognizes worktree directories and does not treat their files as untracked content in the main checkout. However, the absence of a `.gitignore` entry signals intent ambiguously. Third-party tools (editors, search indexers) may descend into the worktree directory unexpectedly. |
+| Branch uniqueness constraint | A branch checked out in a worktree cannot be checked out in the main repo simultaneously. If the user tries to switch `main` to a branch already active in a worktree, git rejects the checkout. |
+| Merge discipline required | Work done in a worktree must be explicitly merged or cherry-picked back to `main`. The worktree branch is not automatically integrated. For a docs repo, this is the correct behavior — but it means improvements discovered during a background task must survive a PR step to be useful. |
+| Auto-generated branch names | The harness generates names like `worktree-12-factor-karpathy-extension`. These are verbose and do not follow the repo's `feat-YYYYMMDD-description` convention. |
+
+---
+
+## Refactoring Opportunities
+
+### 1. Add `.claude/worktrees/` to `.gitignore`
+
+Git does not need this entry to behave correctly, but it documents intent and prevents editors and search tools from indexing worktree content alongside main.
+
+```
+# Add to .gitignore
+.claude/worktrees/
+```
+
+Low effort. No behavior change. Recommended.
+
+### 2. Commit untracked draft files before starting a worktree session
+
+The friction caused by `.12-FACTOR-AGENTS.md` not appearing in the worktree is avoidable. Establish a convention: **stage and commit any in-progress draft files to a scratch branch before delegating to a background agent**. The agent checks out that branch as its worktree base, giving it access to the in-progress content. This is consistent with `STRATEGY.md §1` (never rely on conversational memory; always write it down).
+
+Add to `STRATEGY.md` anti-patterns: "Do not delegate to a background agent while work-in-progress files are untracked. Commit to a scratch branch first."
+
+### 3. Standardize worktree branch naming
+
+Current harness auto-generates `worktree-<task-slug>`. The repo convention is `feat-YYYYMMDD-<slug>` or `chore-YYYYMMDD-<slug>`. Either configure the harness to use the convention, or rename the branch immediately after worktree creation (as done in this session with `git checkout -b feat-20260517-karpathy-wiki`).
+
+### 4. Treat `skills/`, `subagents/`, `templates/` as read-only in worktrees
+
+Background agents working on task-scoped deliverables (analysis docs, session summaries, draft recommendations) should not modify shared reference libraries in the worktree. If an agent discovers a pattern worth adding to `skills/`, it should note it in its output document and leave the `skills/` update for a dedicated PR — not modify the worktree copy, which would require a merge back before the improvement is visible.
+
+Add to `subagents/subagents.md`: "Background agents operating in a worktree must not modify files in `skills/`, `subagents/`, or `templates/` unless the task is explicitly scoped to those files. Improvements to reference libraries belong in a dedicated feature branch, not a background task worktree."
+
+### 5. Karpathy `log.md` and `index.md` must live in a worktree-accessible location
+
+The Karpathy wiki pattern requires `log.md` (append-only execution record) and `index.md` (content catalog) to be readable across sessions. If these files are tracked by git and live in the main checkout, background agents in worktrees can read the current version at worktree-creation time but cannot update the shared log without a merge step.
+
+Two viable approaches:
+
+**Option A — Commit-based (fits current workflow):** `log.md` and `index.md` are tracked files. Each session commits its log entries and index updates to its branch. The merge into `main` is what makes the log durable. Simpler; no new infrastructure; log updates are auditable in git history. Tradeoff: the log is not visible to concurrent sessions until merged.
+
+**Option B — Untracked shared file (outside git):** `log.md` and `index.md` live in an untracked location accessible to all worktrees — e.g., `plans/log.md` (already excluded from git by `plans/*progress.txt` pattern in `.gitignore`... though `log.md` would need explicit exclusion). All worktrees share the same file via the filesystem. Tradeoff: concurrent writes risk corruption; no git history on the log.
+
+**Recommendation:** Option A for this docs-first repo. The log's value is in its git-auditable history. Concurrency conflicts are low-risk when sessions are sequential (one background agent at a time).
+
+---
+
+## Summary Table
+
+| Question | Answer |
+|----------|--------|
+| Is the worktree a full repo copy? | Yes at filesystem level; no at git object level |
+| Disk cost for this repo? | Negligible — docs-first, no build artifacts |
+| Biggest actual friction? | Untracked files invisible to worktrees; branch naming inconsistency |
+| `.gitignore` gap? | `.claude/worktrees/` should be listed to signal intent |
+| Highest-value refactor? | Convention: commit draft files before delegating; treat `skills/` as read-only in worktrees |
+| Karpathy wiki + worktrees? | Option A: commit-based log/index updates per branch; merge to main to persist |


### PR DESCRIPTION
## Summary

- Extends `.12-FACTOR-AGENTS.md` with a new section mapping Karpathy's persistent wiki primitives (`index.md`, `log.md`, wiki pages) onto existing repo artifacts, and revises recommendations for F3, F5, F12, F13 to favor structured markdown over JSON schemas for this docs-first repo
- Adds `_SOLUTIONS/2026-05-17-karpathy-wiki.md` documenting how git worktrees work in this repo — filesystem vs. git-object duplication, benefits and tradeoffs, and five concrete refactoring opportunities

## Changes

**`.12-FACTOR-AGENTS.md`** — new section: *Karpathy Wiki Lens — Persistent Context as Session Efficiency*
- Maps `index.md` / `log.md` / wiki pages to current repo equivalents (`CLAUDE.md` on-demand table, `plans/*-progress.txt`, `skills/` docs)
- Key finding: `CLAUDE.md`'s on-demand table is already a proto-Karpathy `index.md` — formalizing it closes F13 without new infrastructure
- Positions `log.md` + indexed session pages as the F5 fix, replacing the split `*-progress.txt` / session summaries
- Provides a session efficiency protocol (open / work / close / lint) combining `STRATEGY.md` discipline with wiki primitives
- Revised recommendations table for ranks 3–6; F9 and F7 (highest-impact) unchanged

**`_SOLUTIONS/2026-05-17-karpathy-wiki.md`** — worktree reference document
- Explains the filesystem-vs-object-level duplication distinction
- Documents five refactoring opportunities (tracked as issues #57–#61)

## Related Issues

Closes — none (analysis/docs only)  
Spawned — #57, #58, #59, #60, #61

## Test plan

- [x] Review `.12-FACTOR-AGENTS.md` new section for accuracy against `STRATEGY.md` and existing factor table
- [x] Confirm `_SOLUTIONS/2026-05-17-karpathy-wiki.md` refactoring opportunities match issues #57–#61
- [x] Verify no existing files in `skills/`, `subagents/`, or `templates/` were modified