### PR TITLE
Add slash commands and sync skills from project repos

### DIFF
--- a/.claude/commands/debt-scan.md
+++ b/.claude/commands/debt-scan.md
@@ -1,0 +1,44 @@
+---
+description: Scan for technical debt patterns and prioritize remediation
+allowed-tools: Bash(git *), Bash(npm *), Bash(npx *), Bash(wc *), Bash(find *), Read, Glob, Grep
+---
+
+Scan this project for technical debt and produce a prioritized remediation report.
+
+## Scan dimensions
+
+**Code complexity:**
+- Find the 5 largest files by line count (often a sign of god objects/modules)
+- Identify functions longer than 50 lines
+- Flag files with more than 10 imports (high coupling)
+
+**Dependency health:**
+!`npm outdated 2>/dev/null || pip list --outdated 2>/dev/null | head -20`
+- How many dependencies are more than 2 major versions behind?
+- Are there any dependencies with known deprecation notices?
+
+**Test coverage gaps:**
+- Find source files that have no corresponding test file
+- List them with file size (larger untested files = higher risk)
+
+**Code smells:**
+- grep for: any-type assertions (as any, type: any), eslint-disable without explanation, @ts-ignore without comment
+- Find duplicated code blocks (same 10+ lines appearing in multiple files)
+- Check for TODO/FIXME/HACK comments older than 30 days:
+  use `git log` to find when each TODO was introduced
+
+**Architectural smells:**
+- Circular dependencies (if a tool like madge is available)
+- Business logic in API route handlers (should be in service layer)
+- Direct database queries outside of a repository/data-access layer
+
+## Output format
+Group findings by priority:
+🔴 High: Likely to cause incidents or block feature work
+🟡 Medium: Increasing maintenance cost over time
+🔵 Low: Code quality improvements
+
+For each finding, include:
+- The specific file(s) and what's wrong
+- Estimated effort to fix (small/medium/large)
+- A one-line description suitable for a ticket title

--- a/.claude/commands/dissect.md
+++ b/.claude/commands/dissect.md
@@ -1,0 +1,40 @@
+---
+description: Deep structural review of a file or module
+allowed-tools: Read, Glob, Grep
+argument-hint: <file-path-or-directory>
+---
+
+Perform a deep structural review of: $ARGUMENTS
+
+## Review dimensions (check all of these)
+
+**Error handling:**
+- Are all error paths handled explicitly (no empty catch blocks)?
+- Do async operations have proper error propagation?
+- Are there any swallowed errors that would fail silently?
+
+**Edge cases:**
+- What happens with null/undefined/empty inputs?
+- What happens at boundary values (0, -1, MAX_INT, empty arrays)?
+- Are there implicit type coercions that could cause subtle bugs?
+
+**Concurrency:**
+- Could any state mutation cause race conditions if called concurrently?
+- Are shared resources properly synchronized?
+- What happens if this function is called twice before the first call completes?
+
+**Dependencies:**
+- Are imports used? Flag any unused imports.
+- Are there circular dependency risks?
+- Is the module tightly coupled to implementation details it shouldn't know about?
+
+**Naming and structure:**
+- Do function names accurately describe what they do (including side effects)?
+- Are there functions doing more than one thing that should be split?
+
+## Output format
+For each finding, give:
+- Severity: 🔴 Critical (will cause bugs) / 🟡 Warning (could cause issues) / 🔵 Note (improvement)
+- The specific code location
+- What could go wrong
+- A suggested fix (code, not just description)

--- a/.claude/commands/migrate-draft.md
+++ b/.claude/commands/migrate-draft.md
@@ -1,0 +1,36 @@
+---
+description: Draft a database migration with rollback plan
+allowed-tools: Read, Glob, Grep
+argument-hint: <description-of-schema-change>
+---
+
+Generate a database migration for: $ARGUMENTS
+
+## Step 1: Identify the migration system
+!`ls migrations/ db/migrate/ prisma/migrations/ drizzle/ alembic/versions/ 2>/dev/null | head -20`
+
+Read 2-3 existing migration files to identify:
+- ORM/tool (Prisma, Drizzle, Knex, TypeORM, Alembic, Rails, raw SQL)
+- Naming convention (timestamp prefix, sequential numbering)
+- Structure (up/down methods, SQL vs ORM DSL)
+
+## Step 2: Generate the migration
+Create the migration file following the exact conventions from Step 1.
+
+Requirements:
+- Include both UP and DOWN (rollback) logic
+- The DOWN must perfectly reverse the UP
+- For column additions: set a sensible DEFAULT if the column is NOT NULL
+- For column removals in DOWN: document data loss warnings as comments
+- For index changes: check that the index name follows the project's naming convention
+- For table renames: handle foreign key references
+
+## Step 3: Safety checklist
+After the migration code, add a comment block with:
+- [ ] Estimated row count for affected tables (check with: SELECT count(*) FROM table)
+- [ ] Will this lock the table? (ALTER TABLE on large tables can lock for minutes)
+- [ ] Is this backwards-compatible with the current application code?
+- [ ] Can this be deployed independently of the application change?
+- [ ] What happens if the migration fails halfway through?
+
+Do NOT run the migration. Output the file content only.

--- a/.claude/commands/preflight.md
+++ b/.claude/commands/preflight.md
@@ -1,0 +1,26 @@
+---
+description: Pre-commit scan for debug artifacts and code smells
+allowed-tools: Bash(git *), Bash(grep *), Read, Glob
+---
+
+Scan all staged changes for the following issues:
+
+## What to scan
+!`git diff --cached`
+
+## Rules
+Check for ALL of the following in the staged diff:
+1. console.log, console.debug, console.warn statements (unless in a logger utility)
+2. TODO, FIXME, HACK, XXX comments
+3. Commented-out code blocks (3+ consecutive commented lines)
+4. Hardcoded secrets: API keys, tokens, passwords, connection strings
+5. .only or .skip in test files (jest, mocha, vitest)
+6. Debug flags: debugger statements, #debug, verbose: true in config
+7. Large binary files or data dumps added to the commit
+8. Import statements for dev-only packages in production code paths
+
+## Output format
+If ALL checks pass: respond with "✅ Preflight clear. Staged changes look clean."
+
+If ANY issues found: list every issue with its file path and line context.
+Do NOT fix anything. Do NOT unstage anything. Report only.

--- a/.claude/commands/rebuild.md
+++ b/.claude/commands/rebuild.md
@@ -1,0 +1,27 @@
+---
+description: Rebuild working context after /clear
+allowed-tools: Bash(git *), Read, Glob
+---
+
+Load my current working state into this conversation. Read the following:
+
+1. All uncommitted changes (staged and unstaged):
+!`git diff HEAD`
+
+2. The 5 most recent commits with full diffs:
+!`git log --oneline -5`
+
+3. Any TODO/FIXME markers in modified files:
+!`git diff --name-only HEAD | head -20`
+
+Read each modified file listed above. Identify any TODO, FIXME, or HACK comments in those files.
+
+4. Current branch and its relationship to main:
+!`git branch --show-current`
+!`git log main..HEAD --oneline 2>/dev/null || echo "No commits ahead of main"`
+
+After loading all of this, give me a brief summary:
+- What I appear to be working on (inferred from changes)
+- Key files modified
+- Any TODOs or incomplete work flagged in the code
+- How far ahead of main this branch is

--- a/.claude/commands/refactor-safe.md
+++ b/.claude/commands/refactor-safe.md
@@ -1,0 +1,31 @@
+---
+description: Refactor internals without changing public API
+allowed-tools: Read, Grep, Glob
+argument-hint: <file-or-function>
+---
+
+Refactor the internals of: $ARGUMENTS
+
+## Hard constraints
+- DO NOT change any exported function signatures
+- DO NOT change any return types or shapes
+- DO NOT rename any exported symbols
+- DO NOT change the module's public interface in any way
+- DO NOT add new dependencies
+- Preserve all existing behavior, including edge cases and error messages
+
+## What to improve (internal only)
+- Extract repeated logic into private helper functions
+- Simplify nested conditionals (early returns, guard clauses)
+- Remove dead code paths that can never execute
+- Replace magic numbers/strings with named constants
+- Improve variable names within function bodies
+- Reduce function length by extracting logical steps
+
+## Verification
+After refactoring, confirm:
+1. Every exported function/type/constant still has the same name and signature
+2. All existing tests would still pass without modification (don't run them, just verify compatibility)
+3. No new imports were added
+
+Present the refactored code with a brief summary of what changed and why.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,38 @@
+---
+description: Validate and generate PR description from current branch
+allowed-tools: Bash(git *), Bash(gh *), Bash(pytest *), Bash(npm test *), Read, Glob
+---
+
+Prepare a pull request for the current branch.
+
+## Step 1: Pre-flight validation
+Run the test suite before generating anything. If tests fail, stop and report the failures.
+!`git diff --stat main..HEAD`
+
+## Step 2: Assess the diff
+!`git log main..HEAD --oneline`
+!`git diff --stat main..HEAD`
+
+Check:
+- If the diff exceeds 500 lines changed, flag it as a large PR and suggest splitting
+- If the branch has more than 15 commits, suggest squashing before opening
+
+## Step 3: Generate PR description
+Read the actual code changes (not just filenames) to understand what was built:
+!`git diff main..HEAD`
+
+Write a PR description with these sections:
+
+**Summary** (2-3 sentences): What this PR does and why, written for someone who hasn't seen the code.
+
+**Changes** (bullet list): Group related changes together. Reference specific files only when it adds clarity. Skip trivial changes like formatting and import reordering.
+
+**How to test**: Step-by-step instructions a reviewer can follow to verify the changes work. Include specific commands to run, endpoints to hit, or behaviors to observe.
+
+**Risk assessment**: What could go wrong with this change? Does it touch shared infrastructure, modify database schemas, change public APIs, or affect performance-sensitive paths? Be specific. "Low risk" is not useful. "Modifies the prediction endpoint response shape, which could break clients that destructure the old format" is useful.
+
+**Related issues**: Scan commit messages for issue references (#123, JIRA-456) and list them.
+
+## Step 4: Output
+Print the PR description in markdown, ready to paste into GitHub.
+Do NOT create the PR automatically. Output the description for review first.

--- a/.claude/commands/skills-sync.md
+++ b/.claude/commands/skills-sync.md
@@ -1,0 +1,67 @@
+---
+description: Sync skills from all ~/Code project AGENTS/skills/ directories into agents-and-skills/skills/
+allowed-tools: Bash(find *), Bash(grep *), Read, Edit, Write
+---
+
+Scan every project under `~/Code/` for skill files in `AGENTS/skills/` and merge any new
+content into this repo's `skills/` directory.
+
+## Step 1: Discover all project-specific skill files
+
+!`find ~/Code -path "*/AGENTS/skills/*.md" -not -path "*/agents-and-skills/*" -type f | sort`
+
+## Step 2: For each discovered file, classify it
+
+For each file found above, get its basename and check whether `skills/<basename>` exists
+in this repo.
+
+**New file** (no counterpart in `skills/`):
+- Read the source file.
+- Write it verbatim to `skills/<basename>`.
+- Mark it as "added" in the report.
+
+**Existing file** (counterpart already in `skills/`):
+- Run `grep "^## " <source>` and `grep "^## " skills/<basename>` to get the heading sets.
+- Compute new headings = headings in source not present in base.
+- Exclude `See Also` from consideration (it's boilerplate).
+- For each new heading: extract the full section (from that `##` line to the next `##` line
+  or end of file) from the source file, then append it to the base file immediately before
+  the `## See Also` section, or at the end of the file if no `See Also` exists.
+- Mark it as "updated — sections added: <list>" in the report.
+
+**In sync** (base file already contains all headings from source):
+- No action. Mark it as "already in sync" in the report.
+
+## Step 3: Update skills/skills.md for new files only
+
+For each newly added file:
+- Read the file to determine domain and purpose.
+- Add one row to the Reference Files table in `skills/skills.md`.
+- Match the domain grouping order: All → DevOps → CLI → Web → Data/Web → NLP →
+  Legal/Fiscal → Dashboards → Automation. Insert within the correct domain group.
+- Keep "When to load" phrasing concise: short noun phrases, semicolon-separated.
+
+## Step 4: Update CHANGELOG.md
+
+Add a `## YYYY-MM-DD` entry at the top (use today's date). Include:
+- **Added** — one bullet per new skill file, with the source project path in parentheses.
+- **Changed** — one bullet per existing file that received new sections, listing the section
+  names and source project path.
+- Omit the section entirely if there are no changes of that type.
+
+## Step 5: Print a sync report
+
+```
+Skills sync complete
+====================
+Added (N):
+  - wikimedia-svg-sourcing.md  ← will-it-python/AGENTS/skills/
+
+Updated (N):
+  - legal-fiscal-analysis.md  +[Pattern: State-Machine Parsing…]  ← frc-tools/AGENTS/skills/
+
+Already in sync (N):
+  - <filename>  (<source project>)
+```
+
+If nothing changed across all files, say so explicitly: "All project skills already in sync with base."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## 2026-05-26
+
+### Added
+- `skills/wikimedia-svg-sourcing.md` — patterns for downloading public-domain SVGs from Wikimedia Commons: MD5-based URL computation, rate-limit-safe batch downloading (3s delay, ~20-file batches, 15-min cooldown after HTTP 429), HTML error page detection, and ICS signal flag naming conventions. Sourced from `will-it-python` naval flags session (2026-05-23).
+- `.claude/commands/rebuild.md` — `/rebuild`: reloads working context after `/clear`; reads uncommitted diff, last 5 commits, modified-file TODOs, and branch-vs-main delta, then summarizes current state.
+- `.claude/commands/preflight.md` — `/preflight`: pre-commit scan of staged diff for debug artifacts, hardcoded secrets, commented-out code, test-only flags, and dev-only imports.
+- `.claude/commands/dissect.md` — `/dissect <file>`: deep structural review across error handling, edge cases, concurrency, dependencies, and naming; findings rated Critical / Warning / Note.
+- `.claude/commands/refactor-safe.md` — `/refactor-safe <file>`: refactors internals (extract helpers, simplify conditionals, remove dead code) without touching exported signatures or public API.
+- `.claude/commands/ship.md` — `/ship`: validates tests, assesses diff size, and generates a PR description (Summary, Changes, How to test, Risk assessment, Related issues) ready to paste into GitHub.
+- `.claude/commands/migrate-draft.md` — `/migrate-draft <description>`: detects the migration system in use, generates a migration file with UP and DOWN logic matching project conventions, and outputs a safety checklist.
+- `.claude/commands/debt-scan.md` — `/debt-scan`: scans for technical debt across code complexity, dependency health, test coverage gaps, code smells, and architectural smells; findings grouped High / Medium / Low.
+- `.claude/commands/skills-sync.md` — `/skills-sync`: scans all `~/Code/*/AGENTS/skills/` directories, merges new skill files and missing sections into `skills/`, updates `skills/skills.md` index, and appends a CHANGELOG entry.
+
+### Changed
+- `skills/legal-fiscal-analysis.md` — added "Pattern: State-Machine Parsing of PDF-Extracted Legal Code" section: two-region PDF structure (TOC block → body block), four design rules (case-sensitive patterns, explicit state machine, emitted-key dedup, skip on context mismatch), `LegalCodeParser` skeleton. Validated against 69 TCA files, ~37k entries. Sourced from `frc-tools` TCA TSV converter session (2026-05-25).
+- `skills/skills.md` — registered `wikimedia-svg-sourcing.md` in reference table; registered `skills-sync` in invokable commands table.
+
+---
+
 ## 2026-05-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -258,3 +258,5 @@ mypy src/
 
 The `/caveman`, `/grill-me`, and `/write-a-skill` skills are adapted from
 [Matt Pocock's skills library](https://github.com/mattpocock/skills/tree/main/skills/productivity).
+
+The `/debt-scan`, `/dissent`, `/migrate-draft`, `/preflight`, `/rebuild`, `/refactor-safe`, and `/ship` commands [courtesy of Avi Chawla](https://www.dailydoseofds.com/p/10-must-use-slash-commands-in-claude-code/).

--- a/skills/legal-fiscal-analysis.md
+++ b/skills/legal-fiscal-analysis.md
@@ -406,6 +406,93 @@ def test_quarter_for_date() -> None:
 
 ---
 
+## Pattern: State-Machine Parsing of PDF-Extracted Legal Code
+
+PDF-extracted statutory text has a predictable two-region structure that
+requires a state machine — not a simple line-by-line regex pass — because
+headers appear in two forms:
+
+- **Named** (TOC entries): `Chapter 3 Inspection of Volatile Oils` — on one line.
+- **Bare** (body section headers): `Chapter 3` alone, name on the next line.
+
+Body text also contains cross-references and session law citations that match
+section-number patterns and must be silently discarded.
+
+### Key design rules
+
+1. **Case-sensitive patterns.** `^Chapter\s+(\d+)` (no `re.IGNORECASE`). Body
+   text references (`chapter 9 of this title, …`) are lowercase; structural
+   headers are always capitalized. Using `IGNORECASE` causes silent corruption.
+2. **State machine, not flags.** Use explicit states (`LOOKING_TITLE`,
+   `TITLE_NAME`, `PARSING`, `CHAPTER_NAME`, `PART_NAME`) rather than boolean
+   flags. Each state has one clear responsibility.
+3. **Emitted-key dedup.** TOC section listings and body section headers produce
+   identical text. An `emitted_keys: set[str]` prevents double-emission; the
+   first occurrence (from the TOC pass) wins.
+4. **Skip on context mismatch.** When a section number's encoded title/chapter
+   doesn't match current context, skip silently. Mismatches are either PDF
+   line-split artifacts (e.g. `6\n0-1-101`) or inline cross-references — never
+   legitimate new entries, because the TOC pass captured them first.
+
+```python
+class LegalCodeParser:
+    _LOOKING_TITLE = 'LOOKING_TITLE'
+    _TITLE_NAME    = 'TITLE_NAME'
+    _PARSING       = 'PARSING'
+    _CHAPTER_NAME  = 'CHAPTER_NAME'
+    _PART_NAME     = 'PART_NAME'
+
+    def __init__(self):
+        self.state = self._LOOKING_TITLE
+        self.emitted_keys: set[str] = set()
+        # Case-sensitive — body text references use lowercase
+        self.chapter_named_re = re.compile(r'^Chapter\s+(\d+)\s+(.+)$')
+        self.chapter_bare_re  = re.compile(r'^Chapter\s+(\d+)$')
+
+    def process_line(self, line: str):
+        text = line.strip()
+        if not text:
+            return
+
+        if self.state == self._CHAPTER_NAME:
+            # Name line after bare header — already emitted from TOC; skip.
+            self.state = self._PARSING
+            return
+
+        if self.state == self._PARSING:
+            m = self.chapter_named_re.match(text)
+            if m:
+                key = self._make_key(chapter=int(m.group(1)))
+                self._emit(key, m.group(2).strip())
+                return
+
+            m = self.chapter_bare_re.match(text)
+            if m:
+                self.current_chapter = int(m.group(1))
+                self.state = self._CHAPTER_NAME
+                return
+
+            # Section: skip if title/chapter mismatch (cross-ref or artifact)
+            m = self.section_re.match(text)
+            if m:
+                if int(m.group(1)) != self.current_title or \
+                   int(m.group(2)) != self.current_chapter:
+                    return
+                key = self._make_key(section=m.group(3))
+                self._emit(key, m.group(4).strip())
+
+    def _emit(self, key: str, value: str):
+        if key not in self.emitted_keys:
+            self.emitted_keys.add(key)
+            self.output.append(f'{key}\t{value}')
+```
+
+### Tested against
+69 TCA (Tennessee Code Annotated) title files, ~37k entries, zero false
+emissions after applying the above rules. See `src/utils/tca_title_to_tsv.py`.
+
+---
+
 ## See Also
 
 - [`agents/legal-fiscal-agent.md`](../agents/legal-fiscal-agent.md)

--- a/skills/skills.md
+++ b/skills/skills.md
@@ -33,6 +33,7 @@ recipes, and code cookbooks. They are read on demand when an agent needs to know
 | [`cli-development.md`](cli-development.md) | CLI | Click/Typer patterns, terminal UI |
 | [`web-development.md`](web-development.md) | Web | FastAPI, Flask, Django patterns |
 | [`api-integration.md`](api-integration.md) | Data/Web | HTTP clients, retry, pagination |
+| [`wikimedia-svg-sourcing.md`](wikimedia-svg-sourcing.md) | Data/Web | Downloading public-domain SVGs from Wikimedia Commons; MD5 URL computation; rate-limit handling |
 | [`database-access.md`](database-access.md) | Data/Web | Query patterns, parameterized SQL |
 | [`nlp-processing.md`](nlp-processing.md) | NLP | spaCy, Transformers, sklearn patterns |
 | [`legal-fiscal-analysis.md`](legal-fiscal-analysis.md) | Legal/Fiscal | Decimal arithmetic, tax rules, audit trails |
@@ -72,4 +73,5 @@ Run these in order to take a raw idea through to automated implementation:
 | project-review | `/project-review [perspective]` | Structured multi-lens project audit |
 | stress-test | `/stress-test [topic]` | Stress-test a design, code, or proposal with hard questions |
 | write-a-skill | `/write-a-skill [name]` | Scaffold a new slash command skill with correct frontmatter and repo conventions |
+| skills-sync | `/skills-sync` | Scan all ~/Code project AGENTS/skills/ dirs and merge new files/sections into this repo |
 | caveman | `/caveman` | Ultra-compressed responses (~75% fewer tokens) |

--- a/skills/wikimedia-svg-sourcing.md
+++ b/skills/wikimedia-svg-sourcing.md
@@ -1,0 +1,124 @@
+# Skill: Wikimedia Commons SVG Sourcing
+
+Download public-domain SVG files from Wikimedia Commons without an API key,
+using MD5-based URL computation and rate-limit-aware batching.
+
+---
+
+## Quick Reference
+
+```bash
+# Compute the direct upload URL for a Commons file
+python3 -c "
+import hashlib
+name = 'ICS_Alfa.svg'
+h = hashlib.md5(name.encode()).hexdigest()
+print(f'https://upload.wikimedia.org/wikipedia/commons/{h[0]}/{h[:2]}/{name}')
+"
+
+# Download with rate-limit courtesy delay
+curl -sL -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36" \
+  -o ICS_Alfa.svg -w "%{http_code}\n" \
+  "https://upload.wikimedia.org/wikipedia/commons/8/85/ICS_Alfa.svg"
+```
+
+---
+
+## Pattern: MD5 URL Computation
+
+Wikimedia upload server uses the first character and first two characters of
+the MD5 hash of the **filename** (not the full path) to build the directory
+path:
+
+```
+https://upload.wikimedia.org/wikipedia/commons/<h[0]>/<h[:2]>/<filename>
+```
+
+```python
+import hashlib
+
+def wikimedia_url(filename: str) -> str:
+    h = hashlib.md5(filename.encode()).hexdigest()
+    return f"https://upload.wikimedia.org/wikipedia/commons/{h[0]}/{h[:2]}/{filename}"
+```
+
+Alternatively, verify the URL via the Commons API (more reliable, avoids
+guessing filenames):
+
+```bash
+curl -s "https://commons.wikimedia.org/w/api.php?action=query&titles=File:ICS_Alfa.svg&prop=imageinfo&iiprop=url&format=json"
+```
+
+---
+
+## Pattern: Batch Download with Rate-Limit Handling
+
+The upload server (upload.wikimedia.org) imposes aggressive rate limits.
+HTTP 429 responses can persist for 10–15 minutes after a burst.
+
+**Safe parameters:**
+- Delay between requests: **3 seconds minimum**
+- Batch size before mandatory pause: **~20 files**
+- Cooldown after a 429: **15 minutes**
+- User-Agent: set a real browser string (blank UA is blocked outright)
+
+```python
+import hashlib, subprocess, time
+
+UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+
+files = ["ICS_Alfa.svg", "ICS_Bravo.svg", ...]  # filenames to download
+
+for fname in files:
+    h = hashlib.md5(fname.encode()).hexdigest()
+    url = f"https://upload.wikimedia.org/wikipedia/commons/{h[0]}/{h[:2]}/{fname}"
+    result = subprocess.run(
+        ["curl", "-sL", "-A", UA, "-o", fname, "-w", "%{http_code}", url],
+        capture_output=True, text=True,
+    )
+    code = result.stdout.strip()
+    if code != "200":
+        print(f"FAIL {fname}: HTTP {code}")
+    else:
+        print(f"OK   {fname}")
+    time.sleep(3.0)
+```
+
+**Fallback URL** if upload server is still throttled:
+
+```
+https://commons.wikimedia.org/wiki/Special:FilePath/<filename>
+```
+
+---
+
+## Pattern: Verify Downloaded Files
+
+HTTP 4xx/5xx responses write an HTML error page to the `-o` target. Always
+verify by checking size and first bytes — do not assume a `200` code if using
+`-w` separately from `-o`:
+
+```bash
+for f in *.svg; do
+  size=$(stat -f%z "$f")
+  first=$(head -c 10 "$f")
+  if echo "$first" | grep -q "DOCTYPE\|html"; then
+    echo "BAD  $f [$size bytes]"
+  else
+    echo "OK   $f [$size bytes]"
+  fi
+done
+```
+
+Real SVGs from Wikimedia are typically 200–2000 bytes for simple flag designs.
+An HTML 429 error page is ~2000–3000 bytes starting with `<!DOCTYPE html>`.
+
+---
+
+## ICS Signal Flag Naming (Wikimedia Commons)
+
+| Range | Wikimedia filename | Notes |
+|-------|-------------------|-------|
+| Letters A-W, Y-Z | `ICS_<Phonetic>.svg` | e.g. `ICS_Alfa.svg` |
+| Letter X | `ICS_X-ray.svg` | Hyphen required; `ICS_Xray.svg` redirects but may 404 |
+| Digits 0-9 | `ICS_<Word>.svg` | e.g. `ICS_Zero.svg`, `ICS_Niner.svg` (not `ICS_Numeral_Zero.svg`) |


### PR DESCRIPTION
## Summary

- Adds 9 slash commands to `.claude/commands/` (8 ported from Avi Chawla's library + 1 new `/skills-sync`)
- Ports 2 skills from project-specific `AGENTS/skills/` directories into the global `skills/` library
- Adds a missing state-machine parsing section to `legal-fiscal-analysis.md`

## Changes

**New slash commands (`.claude/commands/`):**
- `/rebuild` — reloads working context after `/clear`
- `/preflight` — pre-commit scan for debug artifacts and secrets
- `/dissect` — deep structural review of a file or module
- `/refactor-safe` — refactors internals without changing public API
- `/ship` — generates a PR description from the current branch
- `/migrate-draft` — drafts a DB migration with UP/DOWN logic and safety checklist
- `/debt-scan` — scans for technical debt across complexity, coverage, and architecture
- `/skills-sync` — catch-all command to merge new skills from all `~/Code/*/AGENTS/skills/` dirs into this repo

**New skills (`skills/`):**
- `wikimedia-svg-sourcing.md` — MD5 URL computation, rate-limit-safe batch downloading, file verification, ICS flag naming (sourced from `will-it-python` session 2026-05-23)

**Updated skills:**
- `legal-fiscal-analysis.md` — added "Pattern: State-Machine Parsing of PDF-Extracted Legal Code" section with `LegalCodeParser` skeleton and 4 design rules, validated against 69 TCA files (sourced from `frc-tools` session 2026-05-25)

**Index and docs:**
- `skills/skills.md` — registered `wikimedia-svg-sourcing.md` and `/skills-sync`
- `CHANGELOG.md` — 2026-05-26 entry covering all changes above
- `README.md` — attribution for Avi Chawla commands (already committed)

## Test plan

- [ ] Invoke `/skills-sync` from within this repo and confirm it reports "All project skills already in sync" (since this PR includes the known diffs)
- [ ] Verify `skills/wikimedia-svg-sourcing.md` is present and matches source in `will-it-python/AGENTS/skills/`
- [ ] Verify `skills/legal-fiscal-analysis.md` contains the `LegalCodeParser` class
- [ ] Confirm `skills/skills.md` table has rows for `wikimedia-svg-sourcing.md` and `skills-sync`