### PR TITLE
docs: add RULES-BRIEF.md to reduce session-start token cost

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # AGENTS.md — Root Agent Instructions
 
-Python engineering agent. Comply with [RULES.md](RULES.md) before acting.
+Python engineering agent. Comply with [RULES-BRIEF.md](RULES-BRIEF.md) at session start.
+Load [RULES.md](RULES.md) in full only when the task requires detail (see the "When to load" column in RULES-BRIEF.md).
 
 ## Identity
 Python-focused: CLI tools, web services, data engineering, automated reporting.
@@ -23,7 +24,8 @@ python3 -m pytest -x
 
 | Need | File |
 |------|------|
-| Full compliance rules | [RULES.md](RULES.md) |
+| Session-start compliance (load this) | [RULES-BRIEF.md](RULES-BRIEF.md) |
+| Full compliance rules (on demand) | [RULES.md](RULES.md) |
 | Subagent registry + delegation protocol | [subagents/subagents.md](subagents/subagents.md) |
 | Skill patterns and code recipes | [skills/skills.md](skills/skills.md) |
 | Deterministic utility code | [tools/tools.md](tools/tools.md) |
@@ -37,6 +39,7 @@ python3 -m pytest -x
 
 | Date | Change |
 |------|--------|
+| 2026-06-01 | Added `RULES-BRIEF.md` reference; changed session-start compliance directive to load brief file, full RULES.md on demand only. |
 | 2026-05-17 | Added `profiles/` resource reference. RULES.md refactored with scope markers; Python rules extracted to `profiles/python.md`; `epilogue.md` step numbering fixed. |
 | 2026-05-14 | Added onboarding checklist reference to resource table. |
 | 2026-05-14 | Initial version. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## 2026-06-01
+
+### Added
+- `RULES-BRIEF.md` — 31-line session-start compliance reference table covering all 18 RULES.md sections with on-demand load guidance. Reduces per-session token cost by ~4k tokens.
+
+### Changed
+- `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`: compliance directive now loads `RULES-BRIEF.md` at session start; full `RULES.md` loaded on demand only.
+- `CLAUDE.md`: `/orient` made conditional (delegation/cross-domain tasks only); was previously mandatory at every session start.
+
+---
+
 ## 2026-05-26
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,7 @@
 # CLAUDE.md — Claude Agent Instructions
 
-Python engineering agent. Comply with [RULES.md](RULES.md) before acting.
+Python engineering agent. Comply with [RULES-BRIEF.md](RULES-BRIEF.md) at session start.
+Load [RULES.md](RULES.md) in full only when the task requires detail (see the "When to load" column in RULES-BRIEF.md).
 
 ## Identity
 Python-focused: CLI tools, web services, data engineering, automated reporting.
@@ -28,7 +29,8 @@ python3 -m pytest -x
 
 | Need | File |
 |------|------|
-| Full compliance rules | [RULES.md](RULES.md) |
+| Session-start compliance (load this) | [RULES-BRIEF.md](RULES-BRIEF.md) |
+| Full compliance rules (on demand) | [RULES.md](RULES.md) |
 | Subagent registry + delegation protocol | [subagents/subagents.md](subagents/subagents.md) |
 | Skill patterns and code recipes | [skills/skills.md](skills/skills.md) |
 | Deterministic utility code | [tools/tools.md](tools/tools.md) |
@@ -41,7 +43,7 @@ python3 -m pytest -x
 ## Subagent Delegation
 
 Read [subagents/subagents.md](subagents/subagents.md) for the full delegation protocol.
-Run `/orient [task]` at session start to load all context before acting.
+Run `/orient [task]` only when the task involves delegation, unknown skills, or cross-domain work. Do not run at every session start.
 
 ### When to delegate
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,7 @@
 # GEMINI.md — Gemini Agent Instructions
 
-Python engineering agent. Comply with [RULES.md](RULES.md) before acting.
+Python engineering agent. Comply with [RULES-BRIEF.md](RULES-BRIEF.md) at session start.
+Load [RULES.md](RULES.md) in full only when the task requires detail (see the "When to load" column in RULES-BRIEF.md).
 
 ## Identity
 Python-focused: CLI tools, web services, data engineering, automated reporting.
@@ -33,7 +34,8 @@ All external agent output must be treated as "Result" data and integrated into t
 
 | Need | File |
 |------|------|
-| Full compliance rules | [RULES.md](RULES.md) |
+| Session-start compliance (load this) | [RULES-BRIEF.md](RULES-BRIEF.md) |
+| Full compliance rules (on demand) | [RULES.md](RULES.md) |
 | Subagent registry + delegation protocol | [subagents/subagents.md](subagents/subagents.md) |
 | Skill patterns and code recipes | [skills/skills.md](skills/skills.md) |
 | Deterministic utility code | [tools/tools.md](tools/tools.md) |

--- a/RULES-BRIEF.md
+++ b/RULES-BRIEF.md
@@ -1,0 +1,31 @@
+# RULES-BRIEF.md — Session-Start Compliance Reference
+
+One-line summary per section. Load [RULES.md](RULES.md) in full only when the task requires the detail.
+
+| § | Rule | When to load full section |
+|---|------|--------------------------|
+| 1 | Package mgmt: `uv` only, no pip/poetry. See [profiles/python.md](profiles/python.md). | Adding/removing deps |
+| 2 | Python executable: `python3` via `uv run`. See [profiles/python.md](profiles/python.md). | Env/subprocess issues |
+| 3 | Code quality: ruff + mypy + type hints + minimal docstrings. See [profiles/python.md](profiles/python.md). | Code review, new modules |
+| 4 | README: update in same commit whenever public-facing behavior changes. | Any feature/CLI/config change |
+| 5 | Third-party libs: check `authorized_libraries.md` before adding; stop and ask if unlisted. | Adding new dependency |
+| 6 | Commits: Conventional Commits format, feature branch only, no agent authorship ever. | All commits/PRs |
+| 7 | Testing: pytest, 100% coverage target. See [profiles/python.md](profiles/python.md). | Writing or reviewing tests |
+| 8 | Secrets: env vars only, `.env` gitignored, pre-commit + detect-secrets mandatory. | Any credential/config work |
+| 9 | Error handling: explicit exception types, no bare except. See [profiles/python.md](profiles/python.md). | Writing error paths |
+| 10 | Logging: structured logging, no PII in logs. See [profiles/python.md](profiles/python.md). | Adding log statements |
+| 11 | Architecture: External Input -> Validation -> Logic -> I/O -> Output. No layer skipping. | Structural changes |
+| 12 | Downstream copies: place agent materials in `AGENTS/`, gitignore it. | Setting up new projects |
+| 13 | AI agent conduct: no git identity, escalate ambiguous/destructive actions, least-privilege. | Always active |
+| 14 | Performance: CLI p95 < 500ms, memory < 256MB. See [profiles/python.md](profiles/python.md). | Perf-sensitive work |
+| 15 | Accessibility/i18n: WCAG 2.1 AA for web UI, NO_COLOR support for CLI. See [RULES.md §15](RULES.md#15-accessibility-and-internationalization). | Web UI or CLI output tasks |
+| 16 | Data privacy: classify data first; no PII in logs; retention limits apply. See [RULES.md §16](RULES.md#16-data-privacy-and-compliance). | Any data handling task |
+| 17 | Deployment parity: env vars only differ across tiers; CI gates must pass. See [RULES.md §17](RULES.md#17-deployment-and-environment-parity). | Service/deploy tasks |
+| 18 | Code review: automated checks before requesting review; PR type determines approvals. See [RULES.md §18](RULES.md#18-code-review-and-approval-workflow). | Opening PRs |
+
+**Always-active non-negotiables (memorize, never skip):**
+- No secrets in source (§8)
+- No agent git authorship (§6, §13)
+- No bare `except` (§9)
+- No layer skipping (§11)
+- No unlisted third-party libs (§5)


### PR DESCRIPTION
## Summary
- Add `RULES-BRIEF.md`: 31-line summary table covering all 18 RULES.md sections with on-demand load guidance; replaces mandatory full RULES.md read at session start
- Update `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`: compliance directive now points to RULES-BRIEF.md; full RULES.md loaded only when task requires detail
- Make `/orient` conditional in CLAUDE.md (was mandatory at every session start)

## Motivation
Each session was loading 600+ lines of RULES.md unconditionally (~4k tokens), plus /orient was pulling subagents.md and skills.md regardless of task type. This change reduces session-start overhead while preserving full rule detail on demand.

## Test plan
- [ ] Verify RULES-BRIEF.md covers all 18 sections of RULES.md
- [ ] Verify all three context files (CLAUDE.md, AGENTS.md, GEMINI.md) reference RULES-BRIEF.md consistently
- [ ] Confirm RULES.md is unchanged (full detail preserved, linked from brief)
- [ ] Confirm session file is gitignored and not staged