### PR TITLE
feat: enforce ideate-to-ralph pipeline order with hard gate language

### DIFF
--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -15,4 +15,7 @@ If a question can be answered by exploring the codebase, explore the codebase in
 When shared understanding is reached, summarize:
 - The decisions made and their rationale
 - Open questions that remain unresolved
-- A prompt to the user: "Ready to write the PRD? Run `/prd`."
+
+PIPELINE GATE: Grill session complete. Do not proceed to implementation.
+The human must invoke `/prd [project-name]` to continue.
+Do not create or modify any files until `/prd-to-issues` has run.

--- a/.claude/skills/ideate/SKILL.md
+++ b/.claude/skills/ideate/SKILL.md
@@ -24,3 +24,10 @@ Output:
 - One-line verdict: **Proceed**, **Proceed with caution**, or **Rethink**
 
 Do not hedge. Be precise and direct. Diplomacy is not the goal — correctness is.
+
+---
+
+PIPELINE GATE: This ideation session is analysis, not an implementation instruction.
+Do not create, modify, or delete any files.
+Next step: the human must invoke `/grill-me [topic]`.
+No code changes may occur until `/prd-to-issues` has run and GitHub issues exist.

--- a/.claude/skills/prd/SKILL.md
+++ b/.claude/skills/prd/SKILL.md
@@ -25,7 +25,11 @@ Produce a document with these sections in order:
 
 1. Write the PRD in markdown to `plans/<project-name>-prd.md`.
 2. Also write a task list in JSON to `plans/<project-name>-prd.json` following the schema in `plans/prd.json` — one entry per requirement with `task`, `category`, `priority`, `done`, `description`, `files_affected`, `acceptance_criteria`, and `steps` fields.
-3. Confirm both files written and ask: "Ready to create GitHub issues? Run `/prd-to-issues plans/<project-name>-prd.md`."
+3. Confirm both files written. Then output:
+
+PIPELINE GATE: PRD written. Do not begin implementation.
+The human must invoke `/prd-to-issues plans/<project-name>-prd.md` to continue.
+No code changes may occur until GitHub issues exist.
 
 Constraints:
 - Do not fabricate decisions not established in the conversation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,22 @@ mypy src/
 python3 -m pytest -x
 ```
 
+## Pipeline Discipline
+
+New work follows the pipeline in order:
+
+```
+/ideate → /grill-me → /prd → /prd-to-issues → /ralph
+```
+
+No file creation or code changes may occur before `/prd-to-issues` has run and
+GitHub issues exist. `/ideate` output is analysis, not a task list. Each stage
+boundary is a STOP requiring human invocation of the next command.
+
+Scope check at session start: if `plans/*.json` exists with `done:false` tasks,
+route to `/ralph`, not `/ideate`. If no `plans/*.json` exists and the task is a
+new feature, begin at `/ideate`.
+
 ## On-demand resources (load only what the task requires)
 
 | Need | File |
@@ -37,6 +53,7 @@ python3 -m pytest -x
 
 | Date | Change |
 |------|--------|
+| 2026-06-10 | Added Pipeline Discipline section to all three root context files. Added PIPELINE GATE blocks to `/ideate`, `/grill-me`, and `/prd` skills. Fixed `epilogue.md` §3 to discover context files from inside `AGENTS/` subdirectory. |
 | 2026-05-17 | Added `profiles/` resource reference. RULES.md refactored with scope markers; Python rules extracted to `profiles/python.md`; `epilogue.md` step numbering fixed. |
 | 2026-05-14 | Added onboarding checklist reference to resource table. |
 | 2026-05-14 | Initial version. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## 2026-06-10
+
+### Added
+- `CLAUDE.md`, `GEMINI.md`, `AGENTS.md` — Pipeline Discipline section enforcing ideate-to-ralph stage order at session start, with scope check against `plans/*.json`.
+
+### Changed
+- `.claude/skills/ideate/SKILL.md` — added PIPELINE GATE block at output end: prohibits file creation, requires human to invoke `/grill-me` next.
+- `.claude/skills/grill-me/SKILL.md` — replaced soft "Ready to run /prd?" handoff with hard PIPELINE GATE stop instruction.
+- `.claude/skills/prd/SKILL.md` — replaced soft "Ready to run /prd-to-issues?" handoff with hard PIPELINE GATE stop instruction.
+- `subagents/subagents.md` — scope-validation step (§2) now checks pipeline stage: routes to `/ralph` if `plans/*.json` has incomplete tasks; routes to `/ideate` for new features with no plan file.
+- `templates/epilogue.md` — §3 adds `find` discovery command for locating context files from inside the `AGENTS/` subdirectory; prohibits creating context files inside `AGENTS/`; checklist item updated to match.
+
+---
+
 ## 2026-05-26
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,22 @@ mypy src/
 python3 -m pytest -x
 ```
 
+## Pipeline Discipline
+
+New work follows the pipeline in order:
+
+```
+/ideate → /grill-me → /prd → /prd-to-issues → /ralph
+```
+
+No file creation or code changes may occur before `/prd-to-issues` has run and
+GitHub issues exist. `/ideate` output is analysis, not a task list. Each stage
+boundary is a STOP requiring human invocation of the next command.
+
+Scope check at session start: if `plans/*.json` exists with `done:false` tasks,
+route to `/ralph`, not `/ideate`. If no `plans/*.json` exists and the task is a
+new feature, begin at `/ideate`.
+
 ## On-demand resources (load only what the task requires)
 
 | Need | File |

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -19,6 +19,22 @@ mypy src/
 python3 -m pytest -x
 ```
 
+## Pipeline Discipline
+
+New work follows the pipeline in order:
+
+```
+/ideate → /grill-me → /prd → /prd-to-issues → /ralph
+```
+
+No file creation or code changes may occur before `/prd-to-issues` has run and
+GitHub issues exist. `/ideate` output is analysis, not a task list. Each stage
+boundary is a STOP requiring human invocation of the next command.
+
+Scope check at session start: if `plans/*.json` exists with `done:false` tasks,
+route to `/ralph`, not `/ideate`. If no `plans/*.json` exists and the task is a
+new feature, begin at `/ideate`.
+
 ## Headless Agent Delegation
 
 When a task is highly complex, requires specialized reasoning, or benefits from parallel execution, you may deploy external subagents in headless mode via CLI:

--- a/subagents/subagents.md
+++ b/subagents/subagents.md
@@ -19,7 +19,7 @@ Every agent must declare:
 When an agent receives a task, it must follow this sequence:
 
 1. **Parse the task** — Extract the intent, target, and any constraints from the input.
-2. **Validate scope** — Confirm the task falls within the agent's declared scope. Reject out-of-scope tasks immediately with a clear explanation.
+2. **Validate scope** — Confirm the task falls within the agent's declared scope. Reject out-of-scope tasks immediately with a clear explanation. Also check pipeline stage: if `plans/*.json` exists with `done:false` tasks, the correct action is `/ralph`, not direct implementation or `/ideate`. If no `plans/*.json` exists and the task is a new feature, begin at `/ideate` and do not implement until issues exist.
 3. **Identify required skills** — Determine which registered skills are needed to complete the task (see `skills/` directory).
 4. **Plan before acting** — Produce a short ordered list of steps before executing any action.
 5. **Execute step-by-step** — Carry out each planned step in order. Do not skip steps.

--- a/templates/epilogue.md
+++ b/templates/epilogue.md
@@ -130,6 +130,32 @@ in place rather than creating new lowercase copies.
 | Codex      | `AGENTS.md`  |
 | Perplexity | `AGENTS.md`  |
 
+### Locating context files when operating inside AGENTS/
+
+When the agent materials have been copied into an `AGENTS/` subdirectory of a
+downstream project (per RULES.md §12), the context files live at the project
+root — one level above `AGENTS/`. The agent must locate them before editing.
+
+Run this discovery command from the project root or from within `AGENTS/`:
+
+```bash
+# From the project root
+find . -maxdepth 1 -name "CLAUDE.md" -o -name "GEMINI.md" -o -name "AGENTS.md" | sort
+
+# From inside AGENTS/
+find .. -maxdepth 1 -name "CLAUDE.md" -o -name "GEMINI.md" -o -name "AGENTS.md" | sort
+```
+
+Use the paths returned by the discovery command. If the command returns no
+results, the context files have not been created yet — create them at the
+project root (not inside `AGENTS/`).
+
+**Never create or modify context files inside the `AGENTS/` directory.** That
+directory is gitignored and untracked; files placed there will not persist in
+the downstream repository.
+
+### Updating context files
+
 Each context file should reflect the repository as it stands after this session:
 - Current phase and status.
 - Important files added or changed today, with their purpose.
@@ -138,11 +164,11 @@ Each context file should reflect the repository as it stands after this session:
 - Next steps, replacing any stale items.
 
 **Do not create new lowercase files** (`claude.md`, `gemini.md`, `agents.md`).
-Update the existing uppercase files. If a context file does not exist yet, create
-it at the project root using its correct uppercase name.
+Update the existing uppercase files at the project root. If a context file does
+not exist yet, create it at the project root using its correct uppercase name.
 
 If more than one context file exists, keep the shared project-state content in
-sync. Verify parity with all files that are present:
+sync. Verify parity with all files that are present (run from the project root):
 
 ```bash
 diff CLAUDE.md GEMINI.md
@@ -302,8 +328,9 @@ Report each item as done, skipped with reason, or blocked:
       `skills/skills.md` (or skipped — no new patterns this session).
 - [ ] CHANGELOG.md updated with session entry, or skipped — nothing notable.
 - [ ] `.gitignore` includes `*-session.md` pattern.
-- [ ] Root context files (`CLAUDE.md`, `GEMINI.md`, `AGENTS.md`) updated where
-      present; no new lowercase copies created.
+- [ ] Root context files (`CLAUDE.md`, `GEMINI.md`, `AGENTS.md`) located via
+      discovery command and updated at the project root; no files created inside
+      `AGENTS/`; no new lowercase copies created.
 - [ ] Context files compared and synchronized where more than one exists.
 - [ ] Secrets and local-only files were checked before staging.
 - [ ] Intended changes were committed using Conventional Commits format


### PR DESCRIPTION
## Summary

- Adds explicit `PIPELINE GATE` blocks to `/ideate`, `/grill-me`, and `/prd` skills so agents cannot bypass the pipeline and implement code before issues exist
- Adds a Pipeline Discipline section to `CLAUDE.md` enforcing stage order at session start, including a scope check against `plans/*.json`
- Strengthens `subagents.md` scope-validation step to check pipeline stage before routing to `/ideate` or direct implementation
- Fixes `templates/epilogue.md` §3 to include a `find` discovery command for locating context files when operating from inside the `AGENTS/` subdirectory, with an explicit prohibition against creating files inside `AGENTS/`

## Test plan

- [ ] Run `/ideate [topic]` and confirm output ends with PIPELINE GATE block and no files are created
- [ ] Run `/grill-me [topic]` to completion and confirm it emits GATE instead of soft "Ready to run /prd?" prompt
- [ ] Run `/prd [project]` and confirm output emits GATE after writing PRD files
- [ ] Verify CLAUDE.md Pipeline Discipline section is visible at session start via `/orient`
- [ ] Copy `AGENTS/` into a test project, run epilogue §3, and confirm `find` locates `CLAUDE.md` at project root rather than inside `AGENTS/`