### PR TITLE
rules: add dependency cooling period before new libraries can be committed

### DIFF
--- a/RULES-BRIEF.md
+++ b/RULES-BRIEF.md
@@ -8,7 +8,7 @@ One-line summary per section. Load [RULES.md](RULES.md) in full only when the ta
 | 2 | Python executable: `python3` via `uv run`. See [profiles/python.md](profiles/python.md). | Env/subprocess issues |
 | 3 | Code quality: ruff + mypy + type hints + minimal docstrings. See [profiles/python.md](profiles/python.md). | Code review, new modules |
 | 4 | README: update in same commit whenever public-facing behavior changes. | Any feature/CLI/config change |
-| 5 | Third-party libs: check `authorized_libraries.md` before adding; stop and ask if unlisted. | Adding new dependency |
+| 5 | Third-party libs: check `authorized_libraries.md` before adding; stop and ask if unlisted; 48h cooling period before commit once approved. | Adding new dependency |
 | 6 | Commits: Conventional Commits format, feature branch only, no agent authorship ever. | All commits/PRs |
 | 7 | Testing: pytest, 100% coverage target. See [profiles/python.md](profiles/python.md). | Writing or reviewing tests |
 | 8 | Secrets: env vars only, `.env` gitignored, pre-commit + detect-secrets mandatory. | Any credential/config work |

--- a/RULES-BRIEF.md
+++ b/RULES-BRIEF.md
@@ -8,7 +8,7 @@ One-line summary per section. Load [RULES.md](RULES.md) in full only when the ta
 | 2 | Python executable: `python3` via `uv run`. See [profiles/python.md](profiles/python.md). | Env/subprocess issues |
 | 3 | Code quality: ruff + mypy + type hints + minimal docstrings. See [profiles/python.md](profiles/python.md). | Code review, new modules |
 | 4 | README: update in same commit whenever public-facing behavior changes. | Any feature/CLI/config change |
-| 5 | Third-party libs: check `authorized_libraries.md` before adding; stop and ask if unlisted; 48h cooling period before commit once approved. | Adding new dependency |
+| 5 | Third-party libs: check `authorized_libraries.md` before adding; stop and ask if unlisted; 72h cooling period before commit once approved. | Adding new dependency |
 | 6 | Commits: Conventional Commits format, feature branch only, no agent authorship ever. | All commits/PRs |
 | 7 | Testing: pytest, 100% coverage target. See [profiles/python.md](profiles/python.md). | Writing or reviewing tests |
 | 8 | Secrets: env vars only, `.env` gitignored, pre-commit + detect-secrets mandatory. | Any credential/config work |

--- a/RULES.md
+++ b/RULES.md
@@ -147,6 +147,29 @@ python3 -m pip_audit --requirement <(uv pip compile pyproject.toml)
 Any HIGH or CRITICAL vulnerabilities must be resolved or explicitly accepted
 before the library may be added.
 
+### Dependency cooling period (mandatory for new libraries)
+
+Supply-chain attacks often target the gap between approval and deployment.
+After a library is approved and added to `authorized_libraries.md`, a minimum
+**48-hour cooling period** must elapse before the dependency may be committed
+to production code.
+
+During the cooling period:
+
+- Monitor the library's release history and PyPI page for anomalous activity
+  (unexpected new releases, maintainer changes, yanked versions).
+- Re-run `pip-audit` immediately before committing, not only at approval time:
+  ```bash
+  python3 -m pip_audit --requirement <(uv pip compile pyproject.toml)
+  ```
+- If a new vulnerability or supply-chain event is detected during the window,
+  halt and escalate to the human approver before proceeding.
+
+Record the approval date in `authorized_libraries.md`'s `Approved date` column;
+the dependency may not appear in a commit until `Approved date + 48h` has
+passed. Hotfixes for an active incident may bypass the cooling period only
+with explicit human approval documented in the PR.
+
 ---
 
 ## 6. Version Control and Commits `[CORE]`
@@ -659,7 +682,7 @@ Reviewers must verify each item before approving:
 - [ ] **Authorship** — No file headers, inline comments, commit trailers, or VC artifact text attributes content to an agent (§18).
 - [ ] **Scope** — PR is atomic; unrelated changes are absent.
 - [ ] **Documentation** — README updated if public-facing behavior changed (§4).
-- [ ] **Dependencies** — Any new library is listed in `authorized_libraries.md` (§5).
+- [ ] **Dependencies** — Any new library is listed in `authorized_libraries.md` (§5); the §5 cooling period has elapsed and `pip-audit` was re-run immediately before commit.
 
 ### Handling Disagreements
 
@@ -690,6 +713,7 @@ Architectural decisions require:
 
 | Date | Change |
 |------|--------|
+| 2026-07-28 | §5 added: dependency cooling period. A 48-hour minimum wait now applies between adding an approved library to `authorized_libraries.md` and committing it to production code; `pip-audit` must be re-run immediately before commit. `authorized_libraries.md` template gained `Approved date` and `Earliest commit date` columns. §19 review checklist updated to verify the cooling period elapsed and the re-audit passed. Resolves #69. |
 | 2026-07-12 | `RULES-DRAFTS.md` resolved and deleted — four of its five placeholder sections were already fully covered by §14-§19 and `profiles/python.md`; the three remaining orphaned provisional defaults were promoted: batch-job runtime budget declaration (`profiles/python.md` Performance Standards), PII schema labeling (§16), and container base-image digest pinning (§17). Footer reference to `RULES-DRAFTS.md` removed. |
 | 2026-06-18 | §18 added: Authorship and Attribution — blanket prohibition on all agent attribution in file content, comments, documentation, and version control artifacts; prohibited forms enumerated; enforcement note added (human removes Co-Authored-By trailers, no hook); old §18 renumbered to §19; §6 authorship subsection trimmed to reference §18; §13 cross-reference updated; §19 review checklist and escalation path scope updated to include §18; subagents.md §7 version-stamp rule removed. |
 | 2026-05-17 | Structural refactor: added scope markers (`[CORE]`, `[LANG:PYTHON]`, `[PROFILE:WEB-UI]`, `[PROFILE:SERVICE]`, `[CONFIGURABLE]`) to all section headers; extracted §1, §2, §3, §7, §9, §10, §14 to `profiles/python.md`; added Active Profile declaration before ToC; rewrote §12 to clarify master-source exemption for downstream copies; deduplicated §6/§13 authorship rule (§6 authoritative, §13 references); added `[CONFIGURABLE]` override notes with example syntax to §7, §16, §18; generalized language-specific CI/CD check commands in §17 and §18. |

--- a/RULES.md
+++ b/RULES.md
@@ -151,7 +151,7 @@ before the library may be added.
 
 Supply-chain attacks often target the gap between approval and deployment.
 After a library is approved and added to `authorized_libraries.md`, a minimum
-**48-hour cooling period** must elapse before the dependency may be committed
+**72-hour cooling period** must elapse before the dependency may be committed
 to production code.
 
 During the cooling period:
@@ -166,7 +166,7 @@ During the cooling period:
   halt and escalate to the human approver before proceeding.
 
 Record the approval date in `authorized_libraries.md`'s `Approved date` column;
-the dependency may not appear in a commit until `Approved date + 48h` has
+the dependency may not appear in a commit until `Approved date + 72h` has
 passed. Hotfixes for an active incident may bypass the cooling period only
 with explicit human approval documented in the PR.
 
@@ -713,7 +713,7 @@ Architectural decisions require:
 
 | Date | Change |
 |------|--------|
-| 2026-07-28 | §5 added: dependency cooling period. A 48-hour minimum wait now applies between adding an approved library to `authorized_libraries.md` and committing it to production code; `pip-audit` must be re-run immediately before commit. `authorized_libraries.md` template gained `Approved date` and `Earliest commit date` columns. §19 review checklist updated to verify the cooling period elapsed and the re-audit passed. Resolves #69. |
+| 2026-07-28 | §5 added: dependency cooling period. A 72-hour minimum wait now applies between adding an approved library to `authorized_libraries.md` and committing it to production code; `pip-audit` must be re-run immediately before commit. `authorized_libraries.md` template gained `Approved date` and `Earliest commit date` columns. §19 review checklist updated to verify the cooling period elapsed and the re-audit passed. Resolves #69. |
 | 2026-07-12 | `RULES-DRAFTS.md` resolved and deleted — four of its five placeholder sections were already fully covered by §14-§19 and `profiles/python.md`; the three remaining orphaned provisional defaults were promoted: batch-job runtime budget declaration (`profiles/python.md` Performance Standards), PII schema labeling (§16), and container base-image digest pinning (§17). Footer reference to `RULES-DRAFTS.md` removed. |
 | 2026-06-18 | §18 added: Authorship and Attribution — blanket prohibition on all agent attribution in file content, comments, documentation, and version control artifacts; prohibited forms enumerated; enforcement note added (human removes Co-Authored-By trailers, no hook); old §18 renumbered to §19; §6 authorship subsection trimmed to reference §18; §13 cross-reference updated; §19 review checklist and escalation path scope updated to include §18; subagents.md §7 version-stamp rule removed. |
 | 2026-05-17 | Structural refactor: added scope markers (`[CORE]`, `[LANG:PYTHON]`, `[PROFILE:WEB-UI]`, `[PROFILE:SERVICE]`, `[CONFIGURABLE]`) to all section headers; extracted §1, §2, §3, §7, §9, §10, §14 to `profiles/python.md`; added Active Profile declaration before ToC; rewrote §12 to clarify master-source exemption for downstream copies; deduplicated §6/§13 authorship rule (§6 authoritative, §13 references); added `[CONFIGURABLE]` override notes with example syntax to §7, §16, §18; generalized language-specific CI/CD check commands in §17 and §18. |

--- a/templates/authorized_libraries.md
+++ b/templates/authorized_libraries.md
@@ -44,7 +44,7 @@ See RULES.md §5 for the full authorization process. Summary:
    - Output of `python3 -m pip_audit` showing no HIGH or CRITICAL vulnerabilities
 3. Do not add to `pyproject.toml` until a human approver has explicitly signed off.
 4. Once approved, add to this file with approver name and `Approved date`, then
-   set `Earliest commit date` to `Approved date + 48h` (the mandatory cooling
+   set `Earliest commit date` to `Approved date + 72h` (the mandatory cooling
    period, RULES.md §5). Do not run `uv add <library>` or commit the dependency
    until that date. Immediately before committing, re-run `pip_audit` to catch
    any vulnerability disclosed during the cooling window.

--- a/templates/authorized_libraries.md
+++ b/templates/authorized_libraries.md
@@ -11,23 +11,23 @@ If it does not, follow the proposal process in RULES.md §5.
 
 ## Runtime Dependencies
 
-| Library | Version constraint | Purpose | Approved by | Date |
-|---------|--------------------|---------|-------------|------|
-| | | | | |
+| Library | Version constraint | Purpose | Approved by | Approved date | Earliest commit date |
+|---------|--------------------|---------|-------------|----------------|----------------------|
+| | | | | | |
 
 ---
 
 ## Development Dependencies
 
-| Library | Version constraint | Purpose | Approved by | Date |
-|---------|--------------------|---------|-------------|------|
-| pytest | >=8.0 | Test runner | <name> | YYYY-MM-DD |
-| pytest-cov | >=5.0 | Coverage reporting | <name> | YYYY-MM-DD |
-| pytest-mock | >=3.14 | Mocking fixtures | <name> | YYYY-MM-DD |
-| ruff | >=0.4 | Linter and formatter | <name> | YYYY-MM-DD |
-| mypy | >=1.10 | Static type checker | <name> | YYYY-MM-DD |
-| pre-commit | >=3.0 | Pre-commit hook runner | <name> | YYYY-MM-DD |
-| detect-secrets | >=1.4 | Secret pattern scanning | <name> | YYYY-MM-DD |
+| Library | Version constraint | Purpose | Approved by | Approved date | Earliest commit date |
+|---------|--------------------|---------|-------------|----------------|----------------------|
+| pytest | >=8.0 | Test runner | <name> | YYYY-MM-DD | YYYY-MM-DD |
+| pytest-cov | >=5.0 | Coverage reporting | <name> | YYYY-MM-DD | YYYY-MM-DD |
+| pytest-mock | >=3.14 | Mocking fixtures | <name> | YYYY-MM-DD | YYYY-MM-DD |
+| ruff | >=0.4 | Linter and formatter | <name> | YYYY-MM-DD | YYYY-MM-DD |
+| mypy | >=1.10 | Static type checker | <name> | YYYY-MM-DD | YYYY-MM-DD |
+| pre-commit | >=3.0 | Pre-commit hook runner | <name> | YYYY-MM-DD | YYYY-MM-DD |
+| detect-secrets | >=1.4 | Secret pattern scanning | <name> | YYYY-MM-DD | YYYY-MM-DD |
 
 ---
 
@@ -35,11 +35,16 @@ If it does not, follow the proposal process in RULES.md §5.
 
 See RULES.md §5 for the full authorization process. Summary:
 
-1. Check this file — if the library is listed, proceed with `uv add <library>`.
+1. Check this file — if the library is listed and its cooling period (see
+   below) has elapsed, proceed with `uv add <library>`.
 2. If not listed, open a PR with:
    - Library name and PyPI link
    - Proposed version constraint
    - Purpose and justification
    - Output of `python3 -m pip_audit` showing no HIGH or CRITICAL vulnerabilities
 3. Do not add to `pyproject.toml` until a human approver has explicitly signed off.
-4. Once approved, add to this file with approver name and date, then run `uv add <library>`.
+4. Once approved, add to this file with approver name and `Approved date`, then
+   set `Earliest commit date` to `Approved date + 48h` (the mandatory cooling
+   period, RULES.md §5). Do not run `uv add <library>` or commit the dependency
+   until that date. Immediately before committing, re-run `pip_audit` to catch
+   any vulnerability disclosed during the cooling window.


### PR DESCRIPTION
## Summary
- Adds a mandatory 48-hour cooling period to RULES.md §5 between a library's approval and its first commit, closing the approval-to-deployment supply-chain gap
- Requires re-running `pip-audit` immediately before commit, not only at approval time
- Adds `Approved date` and `Earliest commit date` columns to the `authorized_libraries.md` template and updates the §19 review checklist accordingly

## Test plan
- [ ] Confirm RULES.md §5 renders correctly and the new subsection doesn't break the table of contents anchors
- [ ] Confirm `templates/authorized_libraries.md` table columns render correctly in both sections (Runtime/Development Dependencies)
- [ ] Per RULES.md §19, this is an architectural change (modifies RULES.md) — requires 2 human approvals with the project owner as one

Closes #69