### PR TITLE
chore: worktree hygiene fixes from Karpathy-wiki solutions doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Project-specific
 .file_list
 *-session.md
+.claude/worktrees/
 
 # Python
 __pycache__/

--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -170,3 +170,7 @@ knowledge rather than from zero.
 - Attaching all skills files at once — attach only what the session needs.
 - Skipping the closing ritual — one missed summary breaks the next session's startup.
 - Mixing architectural layers in one session — context bloat stalls progress.
+- Delegating to a background agent while work-in-progress files are untracked
+  — a worktree only contains committed content, so uncommitted files in the
+  main checkout are invisible to it. Commit or stash the in-progress files to
+  a scratch branch first so the worktree can access them.

--- a/subagents/subagents.md
+++ b/subagents/subagents.md
@@ -129,6 +129,14 @@ NOTES (optional):
 - Agents **must not** modify files outside their declared scope without explicit human approval.
 - Agents **must not** store, log, or transmit sensitive data (credentials, PII, proprietary content).
 - Agents **must not** invoke other agents directly; all cross-agent coordination must go through the orchestrator.
+- Background agents operating in a worktree **must not** modify files in
+  `skills/`, `subagents/`, or `templates/` unless that modification is the
+  explicit, sole scope of the task. These are shared reference libraries;
+  a worktree edit is isolated to that branch until merged, and concurrent
+  worktrees touching the same reference file produce avoidable merge
+  conflicts. Improvements to reference libraries discovered incidentally
+  during a background task belong in a dedicated feature branch, noted in
+  the task's output, not applied in-flight.
 
 ---
 


### PR DESCRIPTION
## Summary
- `.gitignore` — add `.claude/worktrees/` so editors/search indexers don't descend into worktree copies (#57)
- `STRATEGY.md` — anti-pattern: commit/stash work-in-progress files before delegating to a background agent, since worktrees only see committed content (#58)
- `subagents/subagents.md` §7 — background agents in a worktree must not edit `skills/`, `subagents/`, or `templates/` unless the task is explicitly scoped to those files (#60)

All three trace back to `_SOLUTIONS/2026-05-17-karpathy-wiki.md`'s refactoring opportunities #1, #2, and #4, and were explicitly deferred pending the prior `chore/rules-drafts-and-registry-cleanup-20260712` cleanup (PR #71).

Per RULES.md §19, the `subagents/subagents.md` commit is architectural (governs agent delegation behavior) and needs 2 human approvals with the project owner as one.

## Test plan
- [ ] Confirm `git status` in the main checkout stays clean with a worktree present under `.claude/worktrees/`
- [ ] Confirm `git worktree add`/`git worktree remove` still work unaffected
- [ ] Read-through: new STRATEGY.md and subagents.md language is unambiguous to a future session

Closes #57, #58, #60