### PR TITLE
feat: implement Karpathy wiki primitives (log.md, index.md, sessions/)

### DIFF
--- a/.12-FACTOR-AGENTS.md
+++ b/.12-FACTOR-AGENTS.md
@@ -8,7 +8,7 @@ Date: 2026-05-17
 
 ## Summary
 
-Repo aligns well on **prompt ownership, control flow, and specialist decomposition** (F1, F2, F8, F10). Critical gaps: no unified execution+business state model (F5), no self-healing error retry loop (F9), no multi-channel trigger support (F11). Partial coverage on context optimization, structured outputs, pause/resume, and human-contact protocol. Adopting missing factors would harden `ralph.sh` loops and reduce agent spin-out risk; tradeoff is added architectural complexity and JSON-discipline overhead for a currently docs-first repo.
+Repo aligns well on **prompt ownership, control flow, and specialist decomposition** (F1, F2, F8, F10). As of 2026-07-29, the Karpathy wiki primitives (`log.md`, `index.md`, `sessions/`) are implemented, closing F13 (pre-fetch context) and partially closing F5 (`log.md` unifies `ralph.sh` execution state; `sessions/` unifies STRATEGY.md's multi-phase business state — but `/epilogue`'s routine single-session summary remains a separate, untracked artifact). Remaining critical gaps: no self-healing error retry loop (F9), no multi-channel trigger support (F11). Partial coverage on context optimization, structured outputs, pause/resume, and human-contact protocol. Adopting the remaining missing factors would harden `ralph.sh` loops and reduce agent spin-out risk; tradeoff is added architectural complexity and JSON-discipline overhead for a currently docs-first repo.
 
 ---
 
@@ -20,7 +20,7 @@ Repo aligns well on **prompt ownership, control flow, and specialist decompositi
 | 2 | Own Your Prompts | ✅ | `RULES.md §13`; `skills/` docs are explicit, versioned prompt context | None — skills/ acts as prompt library |
 | 3 | Own Your Context Window | ⚠️ | `STRATEGY.md §3` skills caching, session scoping | No token-density optimization; no custom XML/structured context formats; context budget is time-based not token-based |
 | 4 | Tools = Structured Outputs | ⚠️ | `subagents/subagents.md` defines delegation protocol | No JSON output schema discipline; tool calls are prose prompts not typed structured outputs |
-| 5 | Unify Execution + Business State | ❌ | Session summaries capture business state; `ralph.sh` tracks task state separately | Two sources of truth — `*-progress.txt` + session summaries; no unified state model; hard to fork/replay/debug |
+| 5 | Unify Execution + Business State | ⚠️ | `log.md` (root) is the single append-only `ralph.sh` execution record, replacing `*-progress.txt`; `sessions/` wiki pages replace STRATEGY.md's ad hoc phase summaries | `/epilogue`'s routine single-session summary is still a separate, untracked `*-session.md` file — not yet folded into the unified record; no fork/replay tooling reads `log.md` programmatically |
 | 6 | Launch / Pause / Resume | ⚠️ | `ralph.sh --prd` iterates with commit-based checkpoints | No webhook resume; no external API; pause is implicit (loop exits, human re-runs); no introspectable agent status |
 | 7 | Contact Humans via Tool Calls | ⚠️ | `RULES.md §13` mandates escalation to human for ambiguous/destructive actions | No structured human-contact tool (no `RequestHumanInput` schema); escalation is prose instruction not typed protocol |
 | 8 | Own Your Control Flow | ✅ | `ralph.sh` owns the loop; `RULES.md §13` defines escalation triggers; `STRATEGY.md` defines session boundaries | None — control flow is explicit and customizable |
@@ -28,7 +28,7 @@ Repo aligns well on **prompt ownership, control flow, and specialist decompositi
 | 10 | Small, Focused Agents | ✅ | `subagents/` roster is specialized by domain; `STRATEGY.md §2` one-specialist-per-task | None — decomposition discipline is strong |
 | 11 | Trigger from Anywhere | ❌ | CLI only (`claude -p`, `gemini -p`, `codex exec`) | No Slack/email/webhook triggers; no outer-loop agent pattern; agents are human-initiated only |
 | 12 | Stateless Reducer | ⚠️ | Session summaries approximate state handoff; each session reads prior summary and produces new one | No formal reducer model; state is prose in markdown, not serializable structured data; no fork/replay |
-| 13 | Pre-fetch Context (Appendix) | ⚠️ | `STRATEGY.md §3` attaches skills docs at session start | Pre-fetch is manual and human-directed; no deterministic "if model will call X, fetch X first" automation |
+| 13 | Pre-fetch Context (Appendix) | ✅ | `index.md` content catalog; grep-and-load protocol in `STRATEGY.md §1`, `.claude/skills/orient/SKILL.md` (session open), and `subagents/subagents.md §2.1` (before subagent invocation) | Grep-and-load is a followed convention, not enforced tooling — same standard as other ✅ factors in this table (e.g. F8) |
 
 ---
 
@@ -110,9 +110,9 @@ Human role: source curation, strategic direction. Agent role: bookkeeping, summa
 
 | Karpathy primitive | Current equivalent | Gap |
 |---|---|---|
-| `index.md` (content catalog) | `CLAUDE.md` "On-demand resources" table | Table exists; no query convention, no update protocol, not linked from subagent prompts |
-| `log.md` (append-only record) | `plans/*-progress.txt` + session summaries | Fragmented — two artifacts, neither append-only by convention |
-| Wiki pages (synthesized summaries) | `skills/` docs + phase summaries | Strong for skill patterns; session summaries are ad hoc and unindexed |
+| `index.md` (content catalog) | Root `index.md`, implemented 2026-07-29 | Closed — query convention (grep-and-load) is documented in `STRATEGY.md §1`, `.claude/skills/orient/SKILL.md`, and `subagents/subagents.md §2.1`; `CLAUDE.md`'s on-demand table remains a separate, human-directed resource index |
+| `log.md` (append-only record) | Root `log.md`, implemented 2026-07-29 | Closed for `ralph.sh` execution state; `/epilogue`'s untracked `*-session.md` summary is still a separate artifact outside the unified record |
+| Wiki pages (synthesized summaries) | `skills/` docs + `sessions/yyyy-mm-dd-<phase>.md` pages | Strong for skill patterns; `sessions/` pages exist for STRATEGY.md's multi-phase ritual but have no backfilled history yet (indexed going forward only) |
 | Lint operation (health-check) | None | Gap — no periodic audit for stale claims across `skills/`, `subagents/`, or summaries |
 | Schema / config | `CLAUDE.md` | Fully covered — schema role already established |
 
@@ -193,3 +193,19 @@ The following replaces the original recommendations for F3, F5, F12, and F13 wit
 | Tradeoff | Detail |
 |----------|--------|
 | Wiki discipline overhead | Maintaining `index.md` and `log.md` requires session-close discipline equivalent to `STRATEGY.md §1`. If the closing ritual is skipped, the wiki drifts. Mitigate by automating `log.md` writes inside `ralph.sh` (per-iteration append) so the execution log stays current even when the session wiki page is missed. |
+
+---
+
+### Implementation Status (2026-07-29)
+
+All three primitives from this section now exist: root `log.md` (schema
+above, `ralph.sh`-automated per-iteration append for both `--prd` and
+general mode), root `index.md` (Session Wiki Pages + Repo Reference Docs
+tables), and `sessions/yyyy-mm-dd-<phase>.md` (format defined in
+`sessions/README.md`). `plans/*-progress.txt` is retired; its two tracked
+files were migrated into `log.md` and removed. Closes GitHub issue #61.
+
+Not done: backfilling historical `*-session.md`/`*-summary.md` files into
+`sessions/` pages (indexed going forward only), and folding `/epilogue`'s
+routine untracked session summary into the unified record (see F5 gap
+above) — both left as deliberate scope boundaries, not oversights.

--- a/.claude/skills/orient/SKILL.md
+++ b/.claude/skills/orient/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 allowed-tools: Read Bash
 ---
 
-Orient yourself to this repository before acting. Complete all four steps in order.
+Orient yourself to this repository before acting. Complete all five steps in order.
 
 ## Step 1 — Core identity and rules
 
@@ -29,7 +29,21 @@ Read both index files:
 - `subagents/subagents.md` — agent identity protocol, delegation rules, registered agents
 - `skills/skills.md` — available reference files and invokable slash commands
 
-## Step 3 — Repo structure survey
+## Step 3 — Content catalog query (pre-fetch)
+
+Grep `index.md` for pages matching the incoming task's domain keywords
+(if $ARGUMENTS is non-empty). Load only the matching `sessions/` pages —
+do not read the whole catalog into context. This closes 12-Factor Agents
+F13 (pre-fetch context); see `.12-FACTOR-AGENTS.md`.
+
+```bash
+grep -i "<keyword>" index.md
+```
+
+If no keywords match, or $ARGUMENTS is empty, skip loading any pages and
+proceed to Step 4.
+
+## Step 4 — Repo structure survey
 
 ```bash
 find . -maxdepth 3 \
@@ -46,13 +60,14 @@ Also run:
 ls -1 subagents/ && ls -1 skills/
 ```
 
-## Step 4 — Orientation summary
+## Step 5 — Orientation summary
 
 Report a concise summary covering:
 1. Agent identity (from CLAUDE.md §Identity)
 2. Which subagents are registered and which to delegate to for the current task
 3. Repo layout — top-level directories and their purpose
 4. Any RULES.md constraints directly relevant to the current task (if one was provided via $ARGUMENTS)
+5. Any `index.md` pages loaded in Step 3, and a one-line note on their relevance
 
 If $ARGUMENTS is non-empty, treat it as the incoming task description and note which
 registered subagent(s) and skills are relevant before proceeding.

--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -30,16 +30,21 @@ Never rely on conversational memory across session boundaries.
 
 **Opening ritual (< 5 minutes):**
 
-1. Read the most recent dated session summary (`yyyy-mm-dd-session-summary.md`).
+1. Grep `index.md` for pages matching today's task domain; load only the
+   matching `sessions/` pages (closes 12-Factor Agents F13 pre-fetch — see
+   `.12-FACTOR-AGENTS.md`).
 2. Read `CLAUDE.md` (root stub or `AGENTS/CLAUDE.md` canonical copy, per RULES.md §12) for current project state.
-3. Read the `Next Steps` section only — ignore the rest of the summary.
+3. Read each loaded page's `Subagent Plan — Next Session` section only — ignore the rest.
 
 **Closing ritual (< 10 minutes):**
 
-1. Invoke `/epilogue` (`.claude/commands/epilogue.md`).
-2. Write a dated session summary using the naming convention
-   `yyyy-mm-dd-<phase>-summary.md` (e.g., `2026-04-29-morning-summary.md`).
-3. Commit and push.
+1. Invoke `/epilogue` (`.claude/commands/epilogue.md`) for the routine
+   session-shutdown steps (skills, `CLAUDE.md`, `CHANGELOG.md`, commit).
+2. Write a session wiki page using `sessions/yyyy-mm-dd-<phase>.md` (see
+   `sessions/README.md` for the required format) — replaces the old
+   `yyyy-mm-dd-<phase>-summary.md` convention.
+3. Add a row to `index.md`'s Session Wiki Pages table pointing to the new page.
+4. Commit and push.
 
 This keeps every session startup under 5 minutes and eliminates re-explanation.
 
@@ -94,7 +99,8 @@ improvement automatically.
 
 At the end of each session, decompose the next session's work into discrete
 subtasks and assign each to a named subagent. Write these assignments into
-the session summary under a `Subagent Plan` heading.
+the session wiki page (`sessions/yyyy-mm-dd-<phase>.md`) under its
+`Subagent Plan — Next Session` heading.
 
 **Example (end of morning session):**
 
@@ -114,12 +120,12 @@ attached. This avoids a bloated single prompt that wastes the context window.
 
 ## Strategy 5 — Progressive Documentation as a Project Asset
 
-At the end of each day, the aggregate session summaries, updated skills files,
-and context documents form a reusable asset for the next project.
+At the end of each day, the aggregate session wiki pages, updated skills
+files, and context documents form a reusable asset for the next project.
 
 **End-of-day actions:**
 
-1. Consolidate the three phase summaries into a single
+1. Consolidate the three session wiki pages into a single
    `yyyy-mm-dd-project-retrospective.md` at the project root.
 2. Extract any new patterns into a new or updated `skills/` document.
 3. Update `CLAUDE.md` if a new agent or workflow was used successfully.
@@ -138,25 +144,25 @@ knowledge rather than from zero.
 ## Daily Execution Checklist
 
 ### Morning Session
-- [ ] Read current context file and most recent retrospective
+- [ ] Grep `index.md` for pages matching today's task domain; read current context file and most recent retrospective
 - [ ] Confirm session scope (architecture layer only)
 - [ ] Attach relevant skills documents; deploy specialist subagent
 - [ ] Produce: scaffold, models, core logic
-- [ ] Write `yyyy-mm-dd-morning-summary.md`; commit and push
+- [ ] Write `sessions/yyyy-mm-dd-morning.md`; add row to `index.md`; commit and push
 
 ### Afternoon Session
-- [ ] Read morning summary (`Next Steps` section only)
-- [ ] Execute subagent plan from morning summary
+- [ ] Read morning session page (`Subagent Plan — Next Session` section only)
+- [ ] Execute subagent plan from morning session page
 - [ ] Attach relevant skills documents per subtask
 - [ ] Produce: I/O layer, tests, integration
-- [ ] Write `yyyy-mm-dd-afternoon-summary.md`; commit and push
+- [ ] Write `sessions/yyyy-mm-dd-afternoon.md`; add row to `index.md`; commit and push
 
 ### Evening Session
-- [ ] Read afternoon summary (`Next Steps` section only)
-- [ ] Execute subagent plan from afternoon summary
+- [ ] Read afternoon session page (`Subagent Plan — Next Session` section only)
+- [ ] Execute subagent plan from afternoon session page
 - [ ] Run full CI checks; invoke review agents
 - [ ] Produce: hardened, documented, deployable artifact
-- [ ] Write `yyyy-mm-dd-evening-summary.md`; commit and push
+- [ ] Write `sessions/yyyy-mm-dd-evening.md`; add row to `index.md`; commit and push
 - [ ] Consolidate into `yyyy-mm-dd-project-retrospective.md`
 - [ ] Extract new patterns into `skills/`; update `CLAUDE.md` if needed
 - [ ] Tag commit; push tags

--- a/index.md
+++ b/index.md
@@ -1,0 +1,36 @@
+# index.md — Content Catalog
+
+Queryable catalog of session wiki pages and key repo reference docs. Grep
+this file for task-domain keywords:
+
+- at session open (see `STRATEGY.md §1`, `.claude/skills/orient/SKILL.md`)
+- before invoking a subagent (see `subagents/subagents.md §2.1`)
+
+then load only the matching pages instead of re-synthesizing context from
+scratch. Closes 12-Factor Agents F13 (pre-fetch context) — see
+`.12-FACTOR-AGENTS.md`.
+
+## Session Wiki Pages
+
+Pages follow the `sessions/yyyy-mm-dd-<phase>.md` format defined in
+`sessions/README.md`. Add one row here when writing a page at session close.
+
+| Date | Phase | Keywords | Page |
+|------|-------|----------|------|
+| | | | |
+
+## Repo Reference Docs
+
+Existing dated docs, indexed for keyword lookup until migrated into the
+`sessions/` wiki format.
+
+| Date | Keywords | Doc |
+|------|----------|-----|
+| 2026-05-14 | ralph loop, PRD mode, epilogue changelog steps | `_SOLUTIONS/2026-05-14-ralph-loop.log` |
+| 2026-05-17 | worktrees, karpathy wiki, background agent isolation, branch naming | `_SOLUTIONS/2026-05-17-karpathy-wiki.md` |
+| 2026-05-17 | rules refactor, profile extraction, scope markers | `_SOLUTIONS/2026-05-17-rules-refactor-session.md` |
+| 2026-05-17 | 12-factor agents, F5, F13, karpathy wiki lens, pre-fetch | `.12-FACTOR-AGENTS.md` |
+| 2026-06-01 | token economization, session efficiency, RULES-BRIEF.md | `2026-06-01-token-economization-session.md` |
+| 2026-06-10 | pipeline discipline, gates, ideate, grill-me, prd, ralph | `2026-06-10-pipeline-gates-session.md` |
+| 2026-06-18 | authorship, attribution, RULES.md §18, co-authored-by | `2026-06-18-authorship-hardening-session.md` |
+| 2026-07-12 | rules-drafts cleanup, registry drift, AGENTS.md consolidation, epilogue command | `2026-07-12-agents-cleanup-session.md` |

--- a/log.md
+++ b/log.md
@@ -1,0 +1,32 @@
+# log.md — Append-Only Execution Record
+
+Single source of truth for `ralph.sh` loop execution state. One line per
+iteration, appended only, never edit or reorder past entries. Replaces the
+retired `plans/*-progress.txt` pattern (Karpathy wiki lens, see
+`.12-FACTOR-AGENTS.md`).
+
+## Schema
+
+```
+[timestamp] [task_id] [status] [err_count] [summary]
+```
+
+- `timestamp` — UTC ISO 8601, `date -u +%Y-%m-%dT%H:%M:%SZ`
+- `task_id` — the PRD task id (`--prd` mode) or a kebab-case slug of the task
+  description (general mode)
+- `status` — `done` (task completed this iteration), `blocked` (iteration
+  failed, will retry), `failed` (max iterations reached without success)
+- `err_count` — number of failed attempts at this `task_id` prior to this
+  entry (`0` on first-try success)
+- `summary` — one-line description of what changed
+
+## Entries
+
+<!-- Migrated from plans/epilogue-refinements-prd-progress.txt on 2026-07-29.
+     plans/test-coverage-progress.txt was empty at migration time. -->
+[2026-05-14T00:00:00Z] [epilogue-changelog-step] [done] [0] iter=1: inserted Step 4.5 (conditional CHANGELOG update) between Step 4 and old Step 5; renumbered Steps 5-8 to 6-9 in templates/epilogue.md
+[2026-05-14T00:00:00Z] [epilogue-step1-local-only] [done] [0] iter=2: updated filename format to yyyy-mm-dd-<descriptor>-session.md, added local-only/do-not-stage note citing .gitignore, updated naming examples table in templates/epilogue.md
+[2026-05-14T00:00:00Z] [epilogue-checklist-audit] [done] [0] iter=3: removed 'Git repository exists locally' and 'origin remote exists and is reachable' items; added CHANGELOG.md and .gitignore *-session.md checklist items; reworded commit-message item to reference Conventional Commits (RULES.md §6); reworded summary item to local-only language
+[2026-05-14T00:00:00Z] [epilogue-final-report] [done] [0] iter=4: replaced Summary field with CHANGELOG field, reordered Final Report fields to: Session closed -> Branch -> Commit -> Remote -> CHANGELOG -> Skills -> Context files -> Status -> Next steps in templates/epilogue.md
+[2026-05-14T00:00:00Z] [gitignore-session-pattern] [done] [0] iter=5: added *-session.md to Project-specific section of .gitignore
+[2026-05-14T00:00:00Z] [remove-dated-root-files] [done] [0] iter=6: removed 6 tracked dated analysis files (2026-05-10/11 *.md) from repo root via git rm

--- a/plans/epilogue-refinements-prd-progress.txt
+++ b/plans/epilogue-refinements-prd-progress.txt
@@ -1,6 +1,0 @@
-2026-05-14 iter=1 task=epilogue-changelog-step — inserted Step 4.5 (conditional CHANGELOG update) between Step 4 and old Step 5; renumbered Steps 5–8 to 6–9 in templates/epilogue.md
-2026-05-14 iter=2 task=epilogue-step1-local-only — updated filename format to yyyy-mm-dd-<descriptor>-session.md, added local-only/do-not-stage note citing .gitignore, updated naming examples table in templates/epilogue.md
-2026-05-14 iter=3 task=epilogue-checklist-audit — removed 'Git repository exists locally' and 'origin remote exists and is reachable' items; added CHANGELOG.md and .gitignore *-session.md checklist items; reworded commit-message item to reference Conventional Commits (RULES.md §6); reworded summary item to local-only language
-2026-05-14 iter=4 task=epilogue-final-report — replaced Summary field with CHANGELOG field, reordered Final Report fields to: Session closed → Branch → Commit → Remote → CHANGELOG → Skills → Context files → Status → Next steps in templates/epilogue.md
-2026-05-14 iter=5 task=gitignore-session-pattern — added *-session.md to Project-specific section of .gitignore
-2026-05-14 iter=6 task=remove-dated-root-files — removed 6 tracked dated analysis files (2026-05-10/11 *.md) from repo root via git rm

--- a/plans/test-coverage-ralph.sh
+++ b/plans/test-coverage-ralph.sh
@@ -43,7 +43,7 @@ for ((i=1; i<=ITERATIONS; i++)); do
     result=$(claude \
         --model "$MODEL" \
         --permission-mode acceptEdits \
-        -p "@plans/test-coverage-plan.md @plans/test-coverage-progress.txt @RULES.md
+        -p "@plans/test-coverage-plan.md @log.md @RULES.md
 PROCESS — follow exactly, one step at a time:
 
 1. ASSESS coverage.
@@ -83,11 +83,11 @@ PROCESS — follow exactly, one step at a time:
    If the tested module now has 100% coverage, mark it:
      Coverage status: COMPLETE
 
-8. APPEND to plans/test-coverage-progress.txt:
-   $(date +%Y-%m-%d) iter=$i — tested: <behavior>, coverage: <N>%, file: <test-file>
+8. APPEND to log.md under '## Entries', following its documented schema:
+   [\$(date -u +%Y-%m-%dT%H:%M:%SZ)] [test-coverage-iter-$i] [done] [0] tested: <behavior>, coverage: <N>%, file: <test-file>
 
 9. COMMIT.
-   git add tests/ plans/test-coverage-plan.md plans/test-coverage-progress.txt
+   git add tests/ plans/test-coverage-plan.md log.md
    git commit -m 'test(<module>): <describe the user behavior being tested>'
 
 CONSTRAINTS:
@@ -108,5 +108,5 @@ CONSTRAINTS:
 done
 
 echo ""
-echo "Reached $ITERATIONS iteration(s). Run again or check test-coverage-progress.txt."
+echo "Reached $ITERATIONS iteration(s). Run again or check log.md."
 exit 0

--- a/ralph.sh
+++ b/ralph.sh
@@ -26,6 +26,7 @@ GOAL_FILE=""
 PRD_FILE=""
 TASK=""
 LOG_DIR="$(dirname "$0")/_SOLUTIONS"
+WIKI_LOG="$(dirname "$0")/log.md"
 
 # ── arg parsing ───────────────────────────────────────────────────────────────
 while [[ $# -gt 0 ]]; do
@@ -48,9 +49,6 @@ done
 if [[ -n "$PRD_FILE" ]]; then
     [[ -f "$PRD_FILE" ]] || { echo "PRD file not found: $PRD_FILE" >&2; exit 1; }
     [[ "$MAX_ITERATIONS" -eq 0 ]] && MAX_ITERATIONS=20
-    PROGRESS_FILE="${PRD_FILE%.json}-progress.txt"
-    mkdir -p "$(dirname "$PROGRESS_FILE")"
-    touch "$PROGRESS_FILE"
 elif [[ -n "$GOAL_FILE" ]]; then
     [[ -f "$GOAL_FILE" ]] || { echo "Goal file not found: $GOAL_FILE" >&2; exit 1; }
     TASK="$(cat "$GOAL_FILE")"
@@ -63,8 +61,10 @@ fi
 
 # ── setup ─────────────────────────────────────────────────────────────────────
 mkdir -p "$LOG_DIR"
+touch "$WIKI_LOG"
 LOG_FILE="$LOG_DIR/$(date +%Y-%m-%d)-ralph-loop.log"
 START_TIME="$(date +%Y-%m-%dT%H:%M:%S)"
+TASK_SLUG="$(echo "$TASK" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '-' | sed 's/-\+/-/g; s/^-//; s/-$//' | cut -c1-40)"
 
 log() { echo "$@" | tee -a "$LOG_FILE"; }
 
@@ -72,11 +72,11 @@ log "═════════════════════════
 log "ralph loop started: $START_TIME"
 if [[ -n "$PRD_FILE" ]]; then
     log "mode: PRD  file: $PRD_FILE"
-    log "progress: $PROGRESS_FILE"
 else
     log "task: $TASK"
     log "tools: $TOOLS"
 fi
+log "wiki log: $WIKI_LOG"
 log "model: $MODEL"
 [[ "$MAX_ITERATIONS" -gt 0 ]] && log "max iterations: $MAX_ITERATIONS"
 log "log: $LOG_FILE"
@@ -100,7 +100,7 @@ while true; do
         result=$(claude \
             --model "$MODEL" \
             --permission-mode acceptEdits \
-            -p "@${PRD_FILE} @${PROGRESS_FILE} @RULES.md
+            -p "@${PRD_FILE} @${WIKI_LOG} @RULES.md
 TASK:
 1. Read ${PRD_FILE}. Find the task with done:false and the lowest priority number.
    If all tasks have done:true, output <promise>COMPLETE</promise> and stop.
@@ -109,9 +109,10 @@ TASK:
 4. Verify every item in acceptance_criteria is satisfied. Fix any failures before continuing.
 5. For shell scripts: bash -n <script>. For Python files changed: ruff format <f> && ruff check --fix <f> && mypy src/ && python3 -m pytest -x
 6. Set done:true for the completed task in ${PRD_FILE}.
-7. Append one line to ${PROGRESS_FILE}: $(date +%Y-%m-%d) iter=${iteration} task=<task-id> — <what changed>
+7. Append one line to ${WIKI_LOG} under '## Entries', following its documented schema:
+   [\$(date -u +%Y-%m-%dT%H:%M:%SZ)] [<task-id>] [done] [<count of prior 'blocked' entries for this task-id in ${WIKI_LOG}>] <what changed>
 8. Commit using Conventional Commits format matching the task's final step.
-CONSTRAINTS: one task per iteration; modify only files_affected unless strictly necessary; no agent attribution in commits (RULES.md §6)." \
+CONSTRAINTS: one task per iteration; modify only files_affected plus ${WIKI_LOG}; no agent attribution in commits (RULES.md §6)." \
             2>&1)
         rc=$?
         echo "$result" | tee -a "$LOG_FILE"
@@ -135,9 +136,13 @@ CONSTRAINTS: one task per iteration; modify only files_affected unless strictly 
             elapsed=$(( $(date +%s) - $(date -j -f '%Y-%m-%dT%H:%M:%S' "$START_TIME" +%s 2>/dev/null || date -d "$START_TIME" +%s) ))
             log ""
             log "✓ success — iteration $iteration  elapsed: ${elapsed}s"
+            printf '[%s] [%s] [done] [%d] %s\n' \
+                "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$TASK_SLUG" "$((iteration - 1))" "${TASK:0:80}" >> "$WIKI_LOG"
             exit 0
         fi
         log "✗ failed (exit ${PIPESTATUS[0]})"
+        printf '[%s] [%s] [blocked] [%d] %s\n' \
+            "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$TASK_SLUG" "$iteration" "${TASK:0:80}" >> "$WIKI_LOG"
     fi
 
     if $interrupted; then
@@ -153,6 +158,10 @@ CONSTRAINTS: one task per iteration; modify only files_affected unless strictly 
 
     if [[ "$MAX_ITERATIONS" -gt 0 && "$iteration" -ge "$MAX_ITERATIONS" ]]; then
         log "Max iterations ($MAX_ITERATIONS) reached without success."
+        if [[ -z "$PRD_FILE" ]]; then
+            printf '[%s] [%s] [failed] [%d] %s (max iterations reached)\n' \
+                "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$TASK_SLUG" "$iteration" "${TASK:0:80}" >> "$WIKI_LOG"
+        fi
         exit 1
     fi
 done

--- a/sessions/README.md
+++ b/sessions/README.md
@@ -1,0 +1,40 @@
+# sessions/ — Session Wiki Pages
+
+Append-only, git-tracked session records for `STRATEGY.md`'s multi-phase
+(morning/afternoon/evening) closing ritual (Strategy 1). Replaces that
+ritual's old `yyyy-mm-dd-<phase>-summary.md` file with a page indexed in
+`index.md`, so a future session can find it by keyword instead of reading
+raw history.
+
+This directory does not change the routine, single-session `/epilogue`
+protocol (`.claude/commands/epilogue.md`), which still writes a local-only,
+gitignored `*-session.md` summary. That convention is intentionally separate
+and unaffected.
+
+## Filename
+
+`sessions/yyyy-mm-dd-<phase>.md` — e.g. `sessions/2026-07-29-morning.md`.
+
+## Required sections
+
+```markdown
+# Session — yyyy-mm-dd <phase>
+
+## Outcomes
+- What shipped, landed, or was verified this session.
+
+## Decisions
+- Decisions made, with enough reasoning that a future session or agent does
+  not have to rediscover it.
+
+## Cross-References
+- Files in `skills/`, `subagents/`, or elsewhere that were touched, or that
+  should be read alongside this page.
+
+## Subagent Plan — Next Session
+1. <subagent-name>: <one subtask, one sentence>
+2. <subagent-name>: <one subtask, one sentence>
+```
+
+After writing a page, add a row to `index.md`'s Session Wiki Pages table
+with the date, phase, a few keywords, and a link to the page.

--- a/subagents/subagents.md
+++ b/subagents/subagents.md
@@ -27,6 +27,23 @@ When an agent receives a task, it must follow this sequence:
 
 ---
 
+## 2.1. Pre-fetch Context (Index Query)
+
+Before invoking a subagent, grep `index.md` for pages relevant to the task
+domain and include the matching pages in the subagent's prompt. This is a
+pre-fetch, not a fallback — do it deterministically for every delegation,
+not only when the orchestrator suspects relevant history exists. Closes
+12-Factor Agents F13 (pre-fetch context); see `.12-FACTOR-AGENTS.md`.
+
+```bash
+grep -i "<task-domain-keyword>" index.md
+```
+
+If no page matches, proceed without attaching one — do not delay
+delegation searching for a match that isn't there.
+
+---
+
 ## 3. Decision-Making Rules
 
 Agents must abide by the following rules at all times:


### PR DESCRIPTION
## Summary
- **log.md** (root) — single append-only execution record for `ralph.sh`, replacing the fragmented `plans/*-progress.txt` pattern. `--prd` mode's per-iteration prompt appends to it directly; general mode (previously untracked) now gets script-controlled entries on success, per-iteration failure, and max-iterations-reached. `plans/test-coverage-ralph.sh` switched to the same file. The two tracked old progress files were migrated into `log.md` and removed.
- **index.md** (root) — content catalog with a Session Wiki Pages table (grows going forward) and a Repo Reference Docs table indexing existing dated docs/`_SOLUTIONS` notes by keyword.
- **sessions/** — `yyyy-mm-dd-<phase>.md` wiki page format (`sessions/README.md`), replacing STRATEGY.md's old `yyyy-mm-dd-<phase>-summary.md` convention for its multi-phase (morning/afternoon/evening) closing ritual. The routine single-session `/epilogue` protocol's local-only `*-session.md` summary is explicitly unchanged and out of scope.
- **STRATEGY.md §1** — opening ritual now greps `index.md` before loading context; closing ritual writes a `sessions/` page and indexes it. Strategy 4/5 wording and the Daily Execution Checklist updated to match.
- **`/orient`** — new Step 3 greps `index.md` for task-domain keywords and loads matching pages before the repo survey (renumbered 4/5).
- **`subagents/subagents.md` §2.1** — new pre-fetch step: grep `index.md` before invoking a subagent, attach matches to its prompt.
- **`.12-FACTOR-AGENTS.md`** — F5 upgraded ❌→⚠️ (log.md/sessions/ unify most state; `/epilogue`'s summary remains a separate untracked artifact), F13 upgraded ⚠️→✅ (pre-fetch mechanism now concretely defined at both session-open and subagent-invocation). Added an Implementation Status note.

Closes #61. Deliberately out of scope (documented in the 12-Factor Implementation Status note): backfilling historical session summaries into `sessions/` pages, and folding `/epilogue`'s untracked summary into the unified record.

Five atomic commits, one per concern, mirroring the PR #71 pattern.

## Test plan
- [ ] `bash -n ralph.sh && bash -n plans/test-coverage-ralph.sh` (already verified clean)
- [ ] `git check-ignore -v log.md` exits 1 (already verified — not ignored)
- [ ] Run `./ralph.sh --prd plans/prd-example.json --max 1` (or similar) and confirm a bracket-schema line lands in `log.md`
- [ ] Run `./ralph.sh "echo hi" --max 1` (general mode) and confirm a `[done]` or `[blocked]` entry lands in `log.md`
- [ ] Read-through `sessions/README.md` and `index.md` for clarity to a future session

Per RULES.md §19 this touches `subagents/subagents.md` and `.claude/skills/orient/SKILL.md` (agent invocation/delegation protocol), so it's architectural — needs 2 human approvals with the project owner as one.