### PR TITLE
docs: close session - issue triage and Karpathy wiki primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## 2026-07-29
+
+### Added
+- Root `log.md` — Karpathy-wiki append-only execution record (bracket schema documented in the file itself), replacing the fragmented `plans/*-progress.txt` convention.
+- Root `index.md` — content catalog with a Session Wiki Pages table and a Repo Reference Docs table indexing existing dated docs/`_SOLUTIONS` notes by keyword.
+- `sessions/` — session wiki page format (`sessions/README.md`: Outcomes, Decisions, Cross-References, Subagent Plan), used by `STRATEGY.md`'s multi-phase (morning/afternoon/evening) closing ritual.
+- `skills/github-issue-creation.md` — Issue Triage and Closure section: verify an issue's factual claims against current repo state before acting on or closing it, plus a closure-comment command pattern.
+- `RULES.md` §5 — dependency cooling period (72h, as merged) between a library's approval and its first commit, with a mandatory `pip-audit` re-run before commit. `templates/authorized_libraries.md` gained `Approved date` / `Earliest commit date` columns; §19 checklist updated to match.
+
+### Changed
+- `ralph.sh` and `plans/test-coverage-ralph.sh` — append structured entries to `log.md` instead of per-PRD `*-progress.txt` files; general (non-PRD) `ralph.sh` mode now logs execution state too, which it previously did not at all.
+- `STRATEGY.md` §1, Strategy 4/5, Daily Execution Checklist — opening ritual greps `index.md` for task-domain pages; closing ritual writes a `sessions/yyyy-mm-dd-<phase>.md` page instead of the old `yyyy-mm-dd-<phase>-summary.md` file.
+- `.claude/skills/orient/SKILL.md` — new Step 3 greps `index.md` for task-domain pages before the repo survey; remaining steps renumbered (4, 5).
+- `subagents/subagents.md` — new §2.1 Pre-fetch Context: grep `index.md` before invoking a subagent; §7 Constraints gained a rule that background agents in a worktree must not edit `skills/`, `subagents/`, or `templates/` unless the task is explicitly scoped to those files.
+- `.gitignore` — added `.claude/worktrees/` so editors/search tools don't descend into worktree copies.
+- `.12-FACTOR-AGENTS.md` — F5 (Unify Execution + Business State) upgraded ❌→⚠️, F13 (Pre-fetch Context) upgraded ⚠️→✅; added an Implementation Status note documenting what shipped and what was deliberately left out of scope.
+
+### Removed
+- `plans/epilogue-refinements-prd-progress.txt` and `plans/test-coverage-progress.txt` — migrated into `log.md`; both retired.
+
+All 7 GitHub issues deferred from the 2026-07-12 cleanup are now resolved:
+#69, #57, #58, #60, #61 merged via PRs #72/#73/#74; #59 and #10 closed as
+outmoded/stale — their cited conventions/files (a never-enforced branch
+naming scheme, a deleted `AGENTS.md`) no longer held.
+
+---
+
 ## 2026-07-12
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,9 @@ new feature, begin at `/ideate`.
 | Language profile + domain-specific profiles | [profiles/](profiles/) |
 | Session shutdown protocol | `/epilogue` ([.claude/commands/epilogue.md](.claude/commands/epilogue.md)) |
 | 12-factor agents analysis + Karpathy wiki lens | [.12-FACTOR-AGENTS.md](.12-FACTOR-AGENTS.md) |
+| Content catalog (grep before loading context; pre-fetch) | [index.md](index.md) |
+| Append-only ralph.sh execution record | [log.md](log.md) |
+| Session wiki pages (STRATEGY.md multi-phase ritual) | [sessions/](sessions/README.md) |
 
 ## Subagent Delegation
 
@@ -98,6 +101,7 @@ Delegate a subtask when it:
 
 | Date | Change |
 |------|--------|
+| 2026-07-29 | Triaged all 7 open GitHub issues deferred from the 2026-07-12 cleanup. Merged: #69 (RULES.md §5 dependency cooling period, 72h as merged — see RULES.md changelog), #57/#58/#60 (worktree hygiene: `.gitignore`, `STRATEGY.md` anti-pattern, `subagents/subagents.md` read-only policy), #61 (Karpathy wiki primitives: root `log.md` replaces `plans/*-progress.txt`; root `index.md` content catalog; `sessions/` wiki pages replace `STRATEGY.md`'s ad hoc phase summaries; pre-fetch query added to `/orient` and `subagents/subagents.md` §2.1; `.12-FACTOR-AGENTS.md` F5/F13 status upgraded). Closed as stale/outmoded: #59 (branch-naming convention was never actually enforced), #10 (referenced deleted `AGENTS.md`; collided with #69's PR). Also corrected `plans/prd.json`'s `consolidate-root-docs` task (marked done, superseded — its premise was the inverse of what the 2026-07-12 consolidation actually did). Added an issue-triage/closure pattern to `skills/github-issue-creation.md`. |
 | 2026-07-12 | `templates/epilogue.md` converted to `.claude/commands/epilogue.md` (invoked as `/epilogue`), since it's a frequently-invoked end-of-session action rather than a copy-once template. Original archived at `archive/epilogue-template-2026-07-12.md`. |
 | 2026-07-12 | Root-doc consolidation completed. `AGENTS.md` and `GEMINI.md` deleted — `CLAUDE.md` is now the sole root context file, in this repo and in downstream copies (`RULES.md` §12 stub pattern). Unique content merged in first: the git-config authorship detail and headless-delegation integration note (from `GEMINI.md`), and the onboarding/containerization resource-table rows (from `AGENTS.md`). |
 | 2026-06-10 | Added Pipeline Discipline section to all three root context files. Added PIPELINE GATE blocks to `/ideate`, `/grill-me`, and `/prd` skills. Fixed `epilogue.md` §3 to discover context files from inside `AGENTS/` subdirectory. |

--- a/skills/github-issue-creation.md
+++ b/skills/github-issue-creation.md
@@ -183,6 +183,48 @@ For bugs, prefer:
 
 ---
 
+## Issue Triage and Closure
+
+Before implementing or closing an existing issue, verify its factual claims
+against current repo state — an issue's body is a snapshot from when it was
+filed and can go stale after unrelated cleanup work (file renames, deletions,
+convention changes). Do not take a cited file path, "established convention,"
+or cross-reference at face value.
+
+Verification pattern:
+
+```bash
+# Does a file/path the issue cites still exist?
+ls <path-cited-in-issue> 2>&1
+
+# Does a "convention" the issue asserts actually hold in history?
+git log --oneline --merges -10
+git branch -a --sort=-committerdate
+
+# Does the issue collide with an unmerged PR touching the same lines?
+gh pr list --state open --json number,title,files
+```
+
+If the premise no longer holds (cited file deleted, convention never
+actually enforced, goal already achieved via a different mechanism), close
+with `gh issue close <n> --comment "..."` explaining specifically what
+changed and why the issue's version should not be resurrected as written —
+not just "stale," but what a future reader would otherwise re-litigate.
+
+```bash
+gh issue close <number> --comment "$(cat <<'EOF'
+Closing as <outmoded|stale>. <One sentence: what the issue claims.> <One
+sentence: what is actually true now, with the file/PR/commit that changed
+it.> <If applicable: what a fresh issue would need to state instead.>
+EOF
+)"
+```
+
+This is a mutation (§Core Rule applies): only close an issue when the user
+asked for it, or the user explicitly delegated triage of open issues.
+
+---
+
 ## Safety Constraints
 
 - Treat GitHub issue creation as an external write operation.

--- a/skills/skills.md
+++ b/skills/skills.md
@@ -22,7 +22,7 @@ recipes, and code cookbooks. They are read on demand when an agent needs to know
 | [`error-handling.md`](error-handling.md) | All | Exception handling patterns |
 | [`logging-observability.md`](logging-observability.md) | All | structlog, logging levels, audit trails |
 | [`configuration-management.md`](configuration-management.md) | All | Config file handling patterns |
-| [`github-issue-creation.md`](github-issue-creation.md) | All | GitHub issue authorization rules and `gh` commands |
+| [`github-issue-creation.md`](github-issue-creation.md) | All | GitHub issue authorization rules, `gh` commands, and stale-premise triage/closure pattern |
 | [`secret-scanning.md`](secret-scanning.md) | All | Pre-commit hook setup, baseline management, credential rotation, incident remediation |
 | [`multi-agent.md`](multi-agent.md) | All | Handoff payload schema, context passing, loop detection, logging |
 | [`prompt-engineering.md`](prompt-engineering.md) | All | Prompt structure standards, injection defense, token efficiency |


### PR DESCRIPTION
## Summary
- CLAUDE.md: resource-table rows for log.md/index.md/sessions/, changelog entry summarizing this session's work
- CHANGELOG.md: 2026-07-29 dated section covering #69, #57/#58/#60, #61, and the #59/#10 closures
- skills/github-issue-creation.md: new "Issue Triage and Closure" section documenting the stale-premise verification pattern used to close #59 and #10 (grep cited files/conventions against current repo state before acting)
- skills/skills.md: one-line description update for the above

Pure documentation/skills-reference changes, no behavior change to agent protocol.

## Test plan
- [ ] Read-through for accuracy against the merged PRs (#72, #73, #74) and closed issues (#59, #10)