### PR TITLE
fix(python): align Python profile and configs with approved PEPs

### DIFF
--- a/.claude/skills/format/SKILL.md
+++ b/.claude/skills/format/SKILL.md
@@ -11,8 +11,8 @@ allowed-tools: Bash(ruff *) Bash(git diff *)
 Run the full format + lint cycle on the project:
 
 ```bash
-ruff format .
-ruff check --fix .
+uv run ruff format .
+uv run ruff check --fix .
 ```
 
 Report which files changed and any lint errors that could not be auto-fixed.

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -3,14 +3,14 @@ name: test
 description: Run the Python test suite with 100% coverage enforcement. Use when the user asks to run tests, check coverage, or verify the test suite passes.
 disable-model-invocation: true
 argument-hint: [path-or-pytest-flags]
-allowed-tools: Bash(python3 -m pytest *)
+allowed-tools: Bash(uv run pytest *)
 ---
 
 Run the full test suite with coverage enforcement.
 Additional arguments or paths: $ARGUMENTS
 
 ```bash
-python3 -m pytest --cov=src --cov-fail-under=100 --cov-report=term-missing $ARGUMENTS
+uv run pytest --cov=src --cov-fail-under=100 --cov-report=term-missing $ARGUMENTS
 ```
 
 Report: tests passed/failed, coverage percentage, any uncovered lines.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## 2026-08-07
+
+### Fixed
+- `templates/pyproject.toml` and `templates/ruff.toml` set `magic-trailing-comma = true`, which is not a valid `[tool.ruff.format]` field (the real one is `skip-magic-trailing-comma`, inverted). `ruff check` errored outright on the shipped template, so every project scaffolded from it had a broken lint gate. Found by materializing the template and running it, not by reading it. Corrected to `skip-magic-trailing-comma = false`, which preserves the intended behavior.
+- `RULES.md` §5 ran its mandatory vulnerability scan as `pip_audit --requirement <(uv pip compile pyproject.toml)`. That command resolves `[project] dependencies` only. With dev dependencies moved to `[dependency-groups]` it would have silently stopped covering them: measured on a probe project, `uv pip compile` resolved 5 packages where `uv export --all-groups` resolved 19. Both occurrences now export from `uv.lock` with hashes. `--no-deps` is justified on the merits (the export is already a complete pinned resolution); `--disable-pip` is documented as a fallback for machines where pip-audit cannot bootstrap its resolution environment, not as part of the canonical command.
+- `templates/pyproject.toml` and `templates/ruff.toml` ignored `D100`/`D104`/`D203`/`D213` without ever selecting `D`, so the profile's docstring rule had no tooling behind it. `D` is now selected with `convention = "google"`. Verified that `D101`, `D102`, and `D103` fire and that `D107` (missing `__init__` docstring) is ignored, since the class docstring documents construction.
+- Both templates ignored `ANN101` and `ANN102`, removed from ruff in 0.8.0. Dropped, along with the same pair in `skills/python-linting.md`.
+
+### Changed
+- `profiles/python.md` Package Management: dev dependencies are declared in `[dependency-groups]` (PEP 735), never in `[project.optional-dependencies]` and never in the pre-standard `[tool.uv] dev-dependencies` table. The `uv pip install -e ".[dev]"` row was a pip shim inside a profile whose own rule is "never use pip"; it is now prohibited. `uv sync` installs the project editable on its own, verified by importing the package from outside its directory and confirming the path resolves into `src/`. `templates/pyproject.toml` and `skills/python-uv-workflow.md` carried the same deprecated table plus a duplicate `dev` extra; both now declare one `[dependency-groups] dev`.
+- `profiles/python.md` Python Executable: every invocation goes through `uv run`. Bare `python3` is prohibited alongside `python` and `py`, because it resolves against `$PATH` and can pick up a system interpreter, which PEP 668 marks as externally managed for that reason. This contradiction had been sitting between the profile and `RULES-BRIEF.md` §2, which already said "`python3` via `uv run`". The sweep touched 20 files, including `CLAUDE.md`'s "After every Python edit" block, the profile's own Enforcement block, `.claude/skills/{test,format}`, `subagents/testing-agent.md`, and `skills/python-{testing,linting,formatting}.md`.
+- `profiles/python.md` Type hints: the Python baseline is stated once as 3.12 and the compatibility hedges are gone. Built-in generics (PEP 585) and `X | None` (PEP 604) are unconditional; `typing.List`, `Dict`, `Tuple`, `Set`, `Optional`, and `Union` are prohibited. `requires-python`, `[tool.mypy] python_version`, `skills/python-formatting.md`, and `skills/python-linting.md` moved from 3.11 to match `.python-version` and ruff's `target-version`, which were already 3.12.
+- `profiles/python.md` no longer mandates `from __future__ import annotations`. A blanket mandate breaks anything reading annotations at runtime (Pydantic, FastAPI route signatures, `dataclasses`, `get_type_hints`), which conflicts with this repo's own FastAPI and Django profiles. PEP 563 is Superseded and PEP 649/749 make deferred evaluation the default in 3.14 without it. Quoted forward references are the replacement, with the `if TYPE_CHECKING:` `NameError` trap called out explicitly, since the coverage config blesses that idiom. `skills/python-formatting.md` and `skills/process-modernization.md` had the import as a routine example and now agree.
+- `templates/pyproject.toml` and `skills/python-uv-workflow.md`: `license = { text = "MIT" }` replaced with an SPDX string plus `license-files` (PEP 639). Confirmed the `LICENSE` file lands in the wheel's `dist-info/licenses/`.
+- The dev-group mypy floor moved from `>=1.10` to `>=1.12`, the release that enables PEP 695 type-parameter syntax by default rather than behind `--enable-incomplete-feature=NewGenericSyntax`.
+- The CI example in `skills/python-uv-workflow.md` installed with `uv sync --all-extras`, which resolves to nothing once dev deps are a group. Changed to plain `uv sync`, which includes the dev group, rather than `--all-groups`, which would newly install every group a project defines.
+
+### Added
+- `profiles/python.md` Error Handling: `raise ... from exc` (PEP 3134) is now a rule with an example, including `from None` for deliberate suppression. The section previously said "re-raise with context" while omitting the one syntax that preserves it. `exc.add_note()` (PEP 678) and `ExceptionGroup`/`except*` for concurrent fan-out (PEP 654) added as rules.
+- `profiles/python.md` Code Quality: a `py.typed` subsection (PEP 561). Verified that hatchling's `packages = ["src/<name>"]` ships the marker with no extra build configuration, so the profile documents that rather than adding a no-op include line.
+- `profiles/python.md` and `skills/python-uv-workflow.md`: PEP 723 inline script metadata as the pattern for one-off scripts, replacing `python3 src/<entry>.py`.
+- `profiles/python.md`: PEP 695 type parameters, PEP 692 `Unpack[TypedDict]`, and PEP 698 `@override` documented as available at 3.12 and explicitly not mandatory, since runtime introspection of `type` aliases is still uneven.
+- `skills/python-uv-workflow.md`: a lock-export section covering the audit requirements export and PEP 751 `pylock.toml`. `uv.lock` remains the source of truth.
+
+---
+
 ## 2026-08-01
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,9 +28,9 @@ artifacts. See [RULES.md §18](RULES.md#18-authorship-and-attribution).
 
 ## After every Python edit
 ```bash
-ruff format <file> && ruff check --fix <file>
-mypy src/
-python3 -m pytest -x
+uv run ruff format <file> && uv run ruff check --fix <file>
+uv run mypy src/
+uv run pytest -x
 ```
 
 ## Pipeline Discipline

--- a/README.md
+++ b/README.md
@@ -241,8 +241,10 @@ Slash commands are invokable skills that live in `.claude/skills/` and appear as
 
 | Setting | Value |
 |---------|-------|
-| Python executable | `python3` |
+| Python baseline | 3.12 |
+| Python invocation | `uv run` (never a bare `python3`) |
 | Package manager | `uv` |
+| Dev dependencies | `[dependency-groups]` (PEP 735) |
 | Linter + formatter | `ruff` |
 | Type checker | `mypy` |
 | Test runner | `pytest` |
@@ -257,16 +259,16 @@ Slash commands are invokable skills that live in `.claude/skills/` and appear as
 uv venv && uv sync
 
 # Run tests with 100% coverage check
-python3 -m pytest --cov=src --cov-fail-under=100
+uv run pytest --cov=src --cov-fail-under=100
 
 # Lint
-ruff check .
+uv run ruff check .
 
 # Format
-ruff format .
+uv run ruff format .
 
 # Type check
-mypy src/
+uv run mypy src/
 ```
 
 ---

--- a/RULES-BRIEF.md
+++ b/RULES-BRIEF.md
@@ -9,9 +9,9 @@ One-line summary per section. Load [RULES.md](RULES.md) in full only when the ta
 
 | § | Rule | When to load full section |
 |---|------|--------------------------|
-| 1 | Package mgmt: `uv` only, no pip/poetry. See [profiles/python.md](profiles/python.md). | Adding/removing deps |
-| 2 | Python executable: `python3` via `uv run`. See [profiles/python.md](profiles/python.md). | Env/subprocess issues |
-| 3 | Code quality: ruff + mypy + type hints + minimal docstrings. See [profiles/python.md](profiles/python.md). | Code review, new modules |
+| 1 | Package mgmt: `uv` only, no pip/poetry. Dev deps in `[dependency-groups]` (PEP 735), never extras. See [profiles/python.md](profiles/python.md). | Adding/removing deps |
+| 2 | Python executable: always `uv run`, never a bare `python3`. Baseline 3.12. See [profiles/python.md](profiles/python.md). | Env/subprocess issues |
+| 3 | Code quality: ruff + mypy + type hints + minimal docstrings. PEP 585/604 spellings; no blanket `from __future__ import annotations`. See [profiles/python.md](profiles/python.md). | Code review, new modules |
 | 4 | README: update in same commit whenever public-facing behavior changes. | Any feature/CLI/config change |
 | 5 | Third-party libs: check [skills/approved-packages.md](skills/approved-packages.md) (authoritative) before adding; stop and ask if unlisted; record the approval in the project's `authorized_libraries.md` and wait the 72h cooling period before commit. Stdlib needs neither. | Adding new dependency |
 | 6 | Commits: Conventional Commits format, feature branch only, no agent authorship ever. | All commits/PRs |

--- a/RULES.md
+++ b/RULES.md
@@ -178,11 +178,26 @@ Before requesting approval, run a vulnerability scan:
 
 ```bash
 uv add --dev pip-audit
-python3 -m pip_audit --requirement <(uv pip compile pyproject.toml)
+uv export --all-groups --no-emit-project \
+  --format requirements-txt > audit-requirements.txt
+uv run pip-audit --requirement audit-requirements.txt --no-deps
 ```
 
 Any HIGH or CRITICAL vulnerabilities must be resolved or explicitly accepted
 before the library may be added.
+
+> **Why not `uv pip compile pyproject.toml`:** that command resolves
+> `[project] dependencies` only. Development dependencies live in
+> `[dependency-groups]` (PEP 735) and would be silently excluded from the scan.
+> `uv export --all-groups` reads `uv.lock`, so it audits exactly what is
+> installed, dev tooling included. Delete `audit-requirements.txt` afterwards or
+> add it to `.gitignore`; it is a scan artifact, not a lock file.
+>
+> **Why `--no-deps`:** the export is already a complete, hash-pinned resolution
+> from `uv.lock`. Letting pip-audit re-resolve would be redundant and could
+> reach the network for versions the lock does not use. If pip-audit cannot
+> build its isolated resolution environment on your machine (an `ensurepip`
+> failure), add `--disable-pip` to use its internal resolver instead.
 
 ### Dependency cooling period (mandatory for new libraries)
 
@@ -199,7 +214,9 @@ During the cooling period:
   (unexpected new releases, maintainer changes, yanked versions).
 - Re-run `pip-audit` immediately before committing, not only at approval time:
   ```bash
-  python3 -m pip_audit --requirement <(uv pip compile pyproject.toml)
+  uv export --all-groups --no-emit-project \
+    --format requirements-txt > audit-requirements.txt
+  uv run pip-audit --requirement audit-requirements.txt --no-deps
   ```
 - If a new vulnerability or supply-chain event is detected during the window,
   halt and escalate to the human approver before proceeding.

--- a/profiles/django.md
+++ b/profiles/django.md
@@ -306,7 +306,7 @@ authorization-failure path.
 
 | Requirement | Detail |
 |---|---|
-| Runner | `uv run python3 -m pytest` |
+| Runner | `uv run pytest` |
 | DB access | Opt in per test, never enabled globally for the suite |
 | Fixtures | `pytest` fixtures and factory functions |
 | Query counts | Assert an exact query count on every list endpoint |
@@ -318,7 +318,7 @@ Django, no extra dependency) unless the pytest integration plugin has been
 authorized under §5.
 
 ```bash
-uv run python3 -m pytest --cov=src --cov-fail-under=100
+uv run pytest --cov=src --cov-fail-under=100
 uv run python3 manage.py makemigrations --check --dry-run
 ```
 
@@ -383,7 +383,7 @@ uv run python3 manage.py collectstatic --no-input
 ### Prohibited
 
 ```bash
-python3 manage.py runserver 0.0.0.0:8000     # NEVER in any deployed environment
+uv run python manage.py runserver 0.0.0.0:8000     # NEVER in any deployed environment
 ```
 
 `runserver` is single-threaded, auto-reloading, and explicitly documented as

--- a/profiles/fastapi.md
+++ b/profiles/fastapi.md
@@ -306,7 +306,7 @@ its authorization-failure path (401 or 403).
 
 | Requirement | Detail |
 |---|---|
-| Runner | `uv run python3 -m pytest` |
+| Runner | `uv run pytest` |
 | Async tests | `pytest-asyncio` |
 | Sync client | `TestClient`, per `skills/web-development.md` Testing |
 | Async client | `httpx.AsyncClient` with `ASGITransport` for async paths |
@@ -315,7 +315,7 @@ its authorization-failure path (401 or 403).
 | External I/O | Mocked per `profiles/python.md` Testing and Coverage |
 
 ```bash
-uv run python3 -m pytest --cov=src --cov-fail-under=100
+uv run pytest --cov=src --cov-fail-under=100
 ```
 
 ### Prohibited

--- a/profiles/flask.md
+++ b/profiles/flask.md
@@ -327,7 +327,7 @@ authorization-failure path.
 
 | Requirement | Detail |
 |---|---|
-| Runner | `uv run python3 -m pytest` |
+| Runner | `uv run pytest` |
 | App fixture | Calls `create_app(TestSettings())`, function or module scoped |
 | Client | `app.test_client()` from that fixture |
 | Database | A transaction rolled back per test, or a per-test schema |
@@ -335,7 +335,7 @@ authorization-failure path.
 | Migrations | A test asserting `alembic upgrade head` succeeds from empty |
 
 ```bash
-uv run python3 -m pytest --cov=src --cov-fail-under=100
+uv run pytest --cov=src --cov-fail-under=100
 ```
 
 ### Prohibited

--- a/profiles/python.md
+++ b/profiles/python.md
@@ -19,10 +19,15 @@ Sections here correspond to `[LANG:PYTHON]` sections in `RULES.md`.
 | Create virtual environment | `uv venv` |
 | Add a runtime dependency | `uv add <package>` |
 | Add a dev-only dependency | `uv add --dev <package>` |
+| Add to a named dependency group | `uv add --group <group> <package>` |
 | Remove a dependency | `uv remove <package>` |
-| Install all dependencies | `uv sync` |
+| Install project and default groups | `uv sync` |
+| Install a specific group | `uv sync --group <group>` |
 | Regenerate lock file | `uv lock` |
-| Install project in editable mode | `uv pip install -e ".[dev]"` |
+| Export pinned requirements | `uv export --all-groups --no-emit-project --format requirements-txt` |
+
+`uv sync` installs the project itself in editable mode. There is no separate
+editable-install step.
 
 ### Prohibited commands
 
@@ -32,28 +37,73 @@ pip install <package>
 pip3 install <package>
 conda install <package>
 poetry add <package>
+uv pip install -e ".[dev]"   # pip shim; dev deps belong in a dependency group
 ```
+
+### Dependency groups vs. optional dependencies
+
+Declare development dependencies in `[dependency-groups]` (PEP 735), never in
+`[project.optional-dependencies]` and never in the pre-standard
+`[tool.uv] dev-dependencies` table.
+
+```toml
+# Correct: local-only, not published in package metadata
+[dependency-groups]
+dev = ["pytest>=8.0", "ruff>=0.4", "mypy>=1.12"]
+
+# Wrong: deprecated pre-standard form
+[tool.uv]
+dev-dependencies = [...]
+```
+
+| Table | Purpose |
+|-------|---------|
+| `[dependency-groups]` | Local development and CI tooling. Not published to an index. |
+| `[project.optional-dependencies]` | Optional *runtime* features consumers opt into via `package[extra]`. |
+
+Dev tooling is never a published extra. Reserve extras for features a consumer
+of the package can actually enable.
 
 ### Rationale
 
 `uv` provides deterministic installs via `uv.lock`, is significantly faster
 than pip, and is the single source of truth for dependency management across
-all projects in this repository.
+all projects in this repository. `[dependency-groups]` is the standard
+(PEP 735) replacement for tool-specific dev-dependency tables.
 
 ---
 
 ## Python Executable
 
-**Rule:** Always invoke Python using `python3`. Never use `python` (which may
-resolve to Python 2 on some systems) or a bare `py` alias.
+**Rule:** Always invoke Python and its tooling through `uv run`. Never call a
+bare `python`, `python3`, or `py` from `$PATH`.
 
 ### Correct usage
 
 ```bash
-python3 -m pytest              # run tests
-python3 -m <package_name>      # run package as module
-python3 src/<entry>.py         # run script directly
-python3 --version              # verify interpreter version
+uv run pytest                  # run tests
+uv run python -m <package>     # run package as module
+uv run ruff check .            # run a dev-group tool
+uv run python --version        # verify interpreter version
+```
+
+### Standalone scripts
+
+For a one-off script outside a project, declare its dependencies inline with
+PEP 723 metadata and run it directly. `uv` builds the environment on demand,
+so no virtual environment or `requirements.txt` is needed.
+
+```python
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["httpx>=0.27"]
+# ///
+
+import httpx
+```
+
+```bash
+uv run report.py               # uv reads the PEP 723 header
 ```
 
 ### Prohibited usage
@@ -62,13 +112,19 @@ python3 --version              # verify interpreter version
 # NEVER use these:
 python script.py
 py script.py
+python3 -m pytest              # may resolve outside the project environment
 ```
 
 ### Rationale
 
-Using `python3` ensures the correct interpreter is always invoked, regardless
-of system-level alias configuration. This prevents silent failures caused by
-Python 2 being picked up from `$PATH`.
+`uv run` guarantees the project's locked environment and pinned interpreter,
+so a command behaves identically on every machine and in CI. A bare `python3`
+resolves against `$PATH` and can silently pick up a system interpreter with a
+different version and different packages installed.
+
+PEP 668 marks system Python installations as externally managed precisely
+because installing into them is unsafe. Routing every invocation through
+`uv run` means the project never touches one.
 
 ---
 
@@ -106,15 +162,24 @@ Rules:
   that can propagate (`Raises:`).
 - Private helpers (`_name`) should have at minimum a one-line docstring.
 
+This rule is enforced, not advisory. The project ruff config selects the `D`
+(pydocstyle) rule set with `convention = "google"`, so a missing or malformed
+docstring fails `ruff check`. A config that ignores `D1xx` codes without
+selecting `D` enforces nothing.
+
 ### Type hints
+
+Baseline interpreter is **Python 3.12** (`.python-version`, `requires-python`,
+ruff `target-version`, and mypy `python_version` all state 3.12). Write for that
+version without compatibility hedges.
 
 - Annotate every function/method signature, including `self`-less methods and
   standalone functions.
-- Use `from __future__ import annotations` at the top of modules that reference
-  forward-declared types.
-- Prefer built-in generics (`list[str]`, `dict[str, int]`) over `typing.List`
-  and `typing.Dict` (Python ≥ 3.9).
-- Use `Optional[X]` only for clarity; prefer `X | None` in Python ≥ 3.10.
+- Use built-in generics: `list[str]`, `dict[str, int]`, `tuple[int, ...]`
+  (PEP 585). `typing.List`, `typing.Dict`, `typing.Tuple`, and `typing.Set` are
+  prohibited.
+- Use `X | None` and `X | Y` (PEP 604). `typing.Optional` and `typing.Union` are
+  prohibited.
 
 ```python
 # Good
@@ -124,7 +189,73 @@ def fetch_records(limit: int, offset: int = 0) -> list[dict[str, str]]:
 # Bad — missing annotations
 def fetch_records(limit, offset=0):
     ...
+
+# Bad: legacy typing aliases
+def fetch_records(limit: int) -> List[Optional[Dict[str, str]]]:
+    ...
 ```
+
+#### Deferred annotations
+
+Do **not** add `from __future__ import annotations` by default.
+
+The import turns every annotation into a string, which breaks any library that
+reads annotations at runtime: Pydantic models, FastAPI route signatures,
+`dataclasses` with resolved field types, and anything calling
+`typing.get_type_hints()` on a type it cannot resolve from the module namespace.
+PEP 563 (which introduced the import) is Superseded, and PEP 649/749 make
+deferred evaluation the default in Python 3.14 without it.
+
+For a genuine import cycle, quote the individual annotation instead:
+
+```python
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from myapp.billing import Invoice
+
+
+def summarize(invoice: "Invoice") -> str:
+    """Render a one-line summary of an invoice."""
+```
+
+The quotes are mandatory here. Without the blanket future import, an unquoted
+`Invoice` in a signature raises `NameError` at import time, because the
+`TYPE_CHECKING` block never executed. Coverage configs exclude
+`if TYPE_CHECKING:` blocks, so this pattern is common and the failure is easy
+to introduce.
+
+Add the future import to a specific module only when that module has a cycle
+that quoting cannot resolve, and note the reason in a comment.
+
+#### Modern typing constructs (available, not mandatory)
+
+Python 3.12 supports these. Use them where they read more clearly than the
+older spelling; none is required.
+
+| Construct | PEP | Use for |
+|-----------|-----|---------|
+| `def f[T](x: T) -> T`, `class Box[T]`, `type Alias = ...` | 695 | Generics without a module-level `TypeVar` |
+| `**kwargs: Unpack[ParamsDict]` | 692 | Precisely typing `**kwargs` |
+| `@override` | 698 | Marking an intentional base-class override |
+
+PEP 695 requires `mypy>=1.12`, which is the floor set in the project template.
+Runtime introspection of `type` aliases is still uneven across libraries, so
+prefer explicit `TypeVar` in code that reflects over its own annotations.
+
+### Distributing types (`py.typed`)
+
+Any package that is installed or published MUST ship a `py.typed` marker so
+downstream type checkers use its inline annotations (PEP 561). Without it, an
+otherwise fully annotated package is treated as untyped by consumers.
+
+```
+src/<package_name>/py.typed      # empty file
+```
+
+With the standard `src/` layout and hatchling's
+`packages = ["src/<package_name>"]`, the marker is included in the wheel
+automatically. No extra build configuration is required.
 
 ### Inline comments
 
@@ -148,9 +279,9 @@ counter += 1
 Run the following after every edit:
 
 ```bash
-ruff format <file_path>        # auto-format
-ruff check --fix <file_path>   # auto-fix lint issues
-mypy src/                      # verify type correctness
+uv run ruff format <file_path>        # auto-format
+uv run ruff check --fix <file_path>   # auto-fix lint issues
+uv run mypy src/                      # verify type correctness
 ```
 
 ---
@@ -172,7 +303,7 @@ coverage.
 - Run the full suite before every PR:
 
 ```bash
-python3 -m pytest --cov=src --cov-fail-under=100
+uv run pytest --cov=src --cov-fail-under=100
 ```
 
 ### Prohibited practices
@@ -203,6 +334,27 @@ except:          # catches KeyboardInterrupt, SystemExit, etc.
     pass
 ```
 
+### Exception chaining
+
+When translating an exception into a domain-specific type, always chain it with
+`raise ... from exc` (PEP 3134). This preserves the original traceback under
+"The above exception was the direct cause of the following exception". A bare
+`raise NewError(...)` inside an `except` block reports the original as an
+incidental "During handling of the above exception", which reads as a bug in the
+handler rather than the real cause.
+
+```python
+# Good: cause is explicit
+try:
+    payload = json.loads(raw)
+except json.JSONDecodeError as exc:
+    raise InvoiceParseError(f"malformed invoice payload: {exc}") from exc
+
+# Deliberately suppressing the cause is also explicit
+except LookupError:
+    raise InvoiceParseError("unknown invoice schema") from None
+```
+
 ### Additional rules
 
 - Use custom exception classes (subclasses of `Exception`) for domain-specific
@@ -212,6 +364,11 @@ except:          # catches KeyboardInterrupt, SystemExit, etc.
   reason.
 - Propagate errors upward to a defined error boundary; do not let errors leak
   silently across layers.
+- Attach diagnostic context with `exc.add_note(...)` (PEP 678) rather than
+  rebuilding the exception message, when re-raising the same exception type.
+- For concurrent fan-out where several tasks can fail independently
+  (`asyncio.TaskGroup`, batch workers), raise an `ExceptionGroup` and handle it
+  with `except*` (PEP 654). Do not discard all but the first failure.
 
 ---
 

--- a/skills/cli-development.md
+++ b/skills/cli-development.md
@@ -465,7 +465,7 @@ def test_rejects_missing_input_file(capsys) -> None:
 those two cases need `pytest.raises`; everything else returns a code normally.
 
 Reserve `subprocess` (the recipe above) for asserting that the installed entry
-point and `python3 -m my_tool` actually work. Business-rule tests should not use
+point and `uv run python -m my_tool` actually work. Business-rule tests should not use
 it: a subprocess runs in a separate interpreter, so its lines miss the parent's
 coverage data and `monkeypatch` in the test process has no effect on it.
 

--- a/skills/nlp-processing.md
+++ b/skills/nlp-processing.md
@@ -10,8 +10,8 @@ using spaCy, Transformers, and related libraries.
 ```bash
 # Install spaCy and download English model
 uv add spacy
-python3 -m spacy download en_core_web_sm    # small, fast
-python3 -m spacy download en_core_web_trf   # transformer-based, accurate
+uv run python -m spacy download en_core_web_sm    # small, fast
+uv run python -m spacy download en_core_web_trf   # transformer-based, accurate
 ```
 
 ---

--- a/skills/process-modernization.md
+++ b/skills/process-modernization.md
@@ -48,8 +48,6 @@ smtp_port = 587
 ```python
 """Load TOML configuration with validation."""
 
-from __future__ import annotations
-
 import tomllib
 from pathlib import Path
 from typing import Any

--- a/skills/python-formatting.md
+++ b/skills/python-formatting.md
@@ -18,10 +18,10 @@ uv add --dev ruff
 
 ### Usage
 ```bash
-ruff format .               # format all Python files in place
-ruff format src/ tests/     # format specific directories
-ruff format . --check       # exit non-zero if any file would change (CI)
-ruff format path/to/file.py # format a single file
+uv run ruff format .               # format all Python files in place
+uv run ruff format src/ tests/     # format specific directories
+uv run ruff format . --check       # exit non-zero if any file would change (CI)
+uv run ruff format path/to/file.py # format a single file
 ```
 
 ---
@@ -31,13 +31,13 @@ ruff format path/to/file.py # format a single file
 ```toml
 [tool.ruff]
 line-length = 88              # Black-compatible default
-target-version = "py311"      # minimum supported Python version
+target-version = "py312"      # minimum supported Python version
 src = ["src"]                 # treat src/ as first-party for import ordering
 
 [tool.ruff.format]
 quote-style = "double"        # "double" or "single"
 indent-style = "space"        # "space" or "tab"
-magic-trailing-comma = true   # respect trailing commas in collections
+skip-magic-trailing-comma = false  # respect trailing commas in collections
 line-ending = "auto"          # "auto", "lf", or "crlf"
 ```
 
@@ -60,10 +60,13 @@ Import order enforced by ruff:
 4. First-party (your package)
 5. Local relative imports
 
+`__future__` sorts first when present, but do not add
+`from __future__ import annotations` by default. See the deferred-annotations
+rule in [profiles/python.md](../profiles/python.md): it breaks libraries that
+read annotations at runtime, and PEP 649 makes it unnecessary at Python 3.14.
+
 ```python
 # Correct import order
-from __future__ import annotations
-
 import os
 import sys
 from pathlib import Path
@@ -106,7 +109,7 @@ Add a formatting check step to your GitHub Actions workflow:
 
 ```yaml
 - name: Check formatting
-  run: ruff format . --check
+  run: uv run ruff format . --check
 ```
 
 ---

--- a/skills/python-linting.md
+++ b/skills/python-linting.md
@@ -18,12 +18,12 @@ Reusable patterns and configuration for Python static analysis using `ruff`
 
 ### Commands
 ```bash
-ruff check .                  # lint all Python files
-ruff check . --fix            # auto-fix safe issues
-ruff check . --fix --unsafe-fixes  # also apply unsafe fixes (review changes)
-ruff check src/               # lint a specific directory
-ruff check path/to/file.py    # lint a single file
-ruff check . --output-format=github  # GitHub Actions annotation format
+uv run ruff check .                  # lint all Python files
+uv run ruff check . --fix            # auto-fix safe issues
+uv run ruff check . --fix --unsafe-fixes  # also apply unsafe fixes (review changes)
+uv run ruff check src/               # lint a specific directory
+uv run ruff check path/to/file.py    # lint a single file
+uv run ruff check . --output-format=github  # GitHub Actions annotation format
 ```
 
 ### Rule Selection (in `pyproject.toml`)
@@ -56,8 +56,7 @@ ignore = [
     "D104",  # allow missing docstring in public package (__init__.py)
     "D203",  # conflicts with D211
     "D213",  # conflicts with D212
-    "ANN101", # `self` type annotation not required
-    "ANN102", # `cls` type annotation not required
+    "D107",  # __init__ is documented by its class docstring
 ]
 fixable = ["ALL"]
 unfixable = ["ERA"]            # never auto-delete commented code
@@ -87,17 +86,17 @@ unfixable = ["ERA"]            # never auto-delete commented code
 
 ### Commands
 ```bash
-mypy src/                     # type-check the src directory
-mypy src/ --strict            # enable all optional error codes
-mypy src/ --ignore-missing-imports  # suppress missing stub warnings
-mypy src/ --html-report reports/mypy/  # generate HTML report
+uv run mypy src/                     # type-check the src directory
+uv run mypy src/ --strict            # enable all optional error codes
+uv run mypy src/ --ignore-missing-imports  # suppress missing stub warnings
+uv run mypy src/ --html-report reports/mypy/  # generate HTML report
 ```
 
 ### Configuration (in `pyproject.toml`)
 
 ```toml
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 strict = true
 warn_return_any = true
 warn_unused_configs = true
@@ -166,7 +165,7 @@ if user is None:
     raise ValueError("user must not be None")
 ```
 
-### `UP006` / `UP007` — Use modern type hints (Python 3.10+)
+### `UP006` / `UP007`: use modern type hints (PEP 585, PEP 604)
 ```python
 # Bad (old style)
 from typing import List, Optional, Union
@@ -242,22 +241,22 @@ items: list = []  # type: ignore[assignment]  -- legacy API returns untyped list
 ```yaml
 # .github/workflows/lint.yml
 - name: Run ruff lint
-  run: ruff check . --output-format=github
+  run: uv run ruff check . --output-format=github
 
 - name: Run ruff format check
-  run: ruff format . --check
+  run: uv run ruff format . --check
 
 - name: Run mypy
-  run: mypy src/
+  run: uv run mypy src/
 ```
 
 ---
 
 ## Lint Checklist
 
-- [ ] `ruff check .` passes with no errors
-- [ ] `ruff format . --check` passes (no formatting changes needed)
-- [ ] `mypy src/` passes with no errors
+- [ ] `uv run ruff check .` passes with no errors
+- [ ] `uv run ruff format . --check` passes (no formatting changes needed)
+- [ ] `uv run mypy src/` passes with no errors
 - [ ] No bare `# noqa` without a specific rule code
 - [ ] No `# type: ignore` without a comment explaining why
 - [ ] All public functions have type annotations

--- a/skills/python-testing.md
+++ b/skills/python-testing.md
@@ -24,38 +24,38 @@ for all new code.
 
 ```bash
 # Run all tests
-python3 -m pytest
+uv run pytest
 
 # Run specific file or directory
-python3 -m pytest tests/unit/test_core.py
-python3 -m pytest tests/unit/
+uv run pytest tests/unit/test_core.py
+uv run pytest tests/unit/
 
 # Run with coverage (terminal report)
-python3 -m pytest --cov=src --cov-report=term-missing
+uv run pytest --cov=src --cov-report=term-missing
 
 # Run with coverage (HTML report — open htmlcov/index.html)
-python3 -m pytest --cov=src --cov-report=html
+uv run pytest --cov=src --cov-report=html
 
 # Enforce 100% coverage (fails build if below threshold)
-python3 -m pytest --cov=src --cov-fail-under=100
+uv run pytest --cov=src --cov-fail-under=100
 
 # Stop on first failure
-python3 -m pytest -x
+uv run pytest -x
 
 # Verbose output
-python3 -m pytest -v
+uv run pytest -v
 
 # Run only tests matching a keyword
-python3 -m pytest -k "tax or invoice"
+uv run pytest -k "tax or invoice"
 
 # Run tests marked as "unit"
-python3 -m pytest -m unit
+uv run pytest -m unit
 
 # Show locals on failure
-python3 -m pytest -l
+uv run pytest -l
 
 # Re-run failed tests from last run
-python3 -m pytest --lf
+uv run pytest --lf
 ```
 
 ---
@@ -317,7 +317,7 @@ def test_pipeline_writes_to_database(test_db_url: str) -> None:
 Run integration tests in isolation:
 
 ```bash
-python3 -m pytest tests/integration/ -m integration
+uv run pytest tests/integration/ -m integration
 ```
 
 ### Coverage Minimum

--- a/skills/python-uv-workflow.md
+++ b/skills/python-uv-workflow.md
@@ -71,7 +71,7 @@ source .venv/bin/activate        # macOS/Linux
 .venv\Scripts\activate           # Windows
 
 # uv commands work WITHOUT activating the venv
-uv run python3 script.py         # auto-uses project's venv
+uv run python script.py          # auto-uses project's venv
 ```
 
 ---
@@ -82,8 +82,11 @@ uv run python3 script.py         # auto-uses project's venv
 ```bash
 uv add requests                  # add runtime dependency
 uv add "requests>=2.28,<3"       # with version constraint
-uv add --dev pytest pytest-cov   # dev-only dependencies
-uv add --optional dev mypy ruff  # optional dependency group
+uv add --dev pytest pytest-cov   # -> [dependency-groups] dev (PEP 735)
+uv add --group docs mkdocs       # -> [dependency-groups] docs
+
+# Add an optional RUNTIME feature (published extra, not dev tooling)
+uv add --optional excel openpyxl # -> [project.optional-dependencies] excel
 
 # Add with extras
 uv add "fastapi[standard]"
@@ -98,16 +101,37 @@ uv remove --dev pytest           # remove dev dependency
 
 ### Syncing the environment
 ```bash
-uv sync                          # install all deps from uv.lock
-uv sync --no-dev                 # install only runtime deps (production)
-uv sync --extra dev              # install with optional dev group
+uv sync                          # project (editable) + dev group, from uv.lock
+uv sync --no-dev                 # runtime deps only (production)
+uv sync --group docs             # add a named dependency group
+uv sync --all-groups             # every dependency group
+uv sync --extra excel            # a published runtime extra
 ```
+
+`uv sync` installs the project itself in editable mode. Never run
+`uv pip install -e ".[dev]"`.
 
 ### Locking
 ```bash
 uv lock                          # regenerate uv.lock from pyproject.toml
 uv lock --upgrade                # upgrade all deps to latest compatible versions
 uv lock --upgrade-package requests  # upgrade a single package
+```
+
+### Exporting the lock
+
+`uv.lock` stays the source of truth. Export only to feed tools that cannot read
+it, such as vulnerability scanners or a non-uv deployment target.
+
+```bash
+# requirements.txt with hashes, for pip-audit
+uv export --all-groups --no-emit-project \
+  --format requirements-txt > audit-requirements.txt
+
+# add --no-hashes only for a legacy pipeline that rejects hash lines
+
+# pylock.toml, the standardized lock interchange format (PEP 751)
+uv export --format pylock.toml -o pylock.toml
 ```
 
 ### Listing installed packages
@@ -122,19 +146,43 @@ uv pip freeze                    # requirements.txt format output
 ## Running Code
 
 ```bash
-# Run a script using the project's venv
-uv run python3 src/my_package/__main__.py
+# Run a module using the project's venv
+uv run python -m my_package
 
 # Run pytest
-uv run python3 -m pytest
+uv run pytest
 
 # Run any command in the project's venv context
 uv run ruff check .
 uv run mypy src/
 
 # Run a script with inline dependencies (no project required)
-uv run --with requests python3 fetch.py
+uv run --with requests fetch.py
 ```
+
+### Standalone scripts with PEP 723 metadata
+
+A script can declare its own dependencies in a comment header. `uv run` builds
+a throwaway environment for it, so no project, venv, or `requirements.txt` is
+involved.
+
+```python
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["httpx>=0.27", "rich>=13.0"]
+# ///
+
+import httpx
+from rich import print
+```
+
+```bash
+uv run report.py                 # uv reads the header and resolves deps
+uv add --script report.py httpx  # add a dependency to the header
+```
+
+Prefer this over `uv run --with <pkg>`: the dependency list lives with the
+script instead of in shell history.
 
 ---
 
@@ -147,21 +195,13 @@ version = "0.1.0"
 description = "What this project does"
 readme = "README.md"
 requires-python = ">=3.12"
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [{ name = "Nicholas Carsner", email = "nicholascarsner@gmail.com" }]
 
 dependencies = [
     "requests>=2.28",
     "pandas>=2.0",
-]
-
-[project.optional-dependencies]
-dev = [
-    "pytest>=8.0",
-    "pytest-cov>=5.0",
-    "pytest-mock>=3.14",
-    "ruff>=0.4",
-    "mypy>=1.10",
 ]
 
 [project.scripts]
@@ -174,14 +214,22 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/my_project"]
 
-[tool.uv]
-dev-dependencies = [
+# Dependency groups (PEP 735): local dev tooling, never published.
+# NOT [project.optional-dependencies]; extras are for optional runtime
+# features consumers opt into via `my-project[extra]`.
+[dependency-groups]
+dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
+    "pytest-mock>=3.14",
     "ruff>=0.4",
-    "mypy>=1.10",
+    "mypy>=1.12",
 ]
 ```
+
+The pre-standard `[tool.uv] dev-dependencies` table is deprecated. If a project
+still has one, `uv add --dev` keeps writing to it, so migrate the table by hand
+and re-run `uv lock` to confirm the resolution is unchanged.
 
 ---
 
@@ -218,14 +266,14 @@ uv sync
 ```bash
 uv lock --upgrade
 uv sync
-python3 -m pytest               # verify nothing broke
+uv run pytest                   # verify nothing broke
 ```
 
 ### Add a new feature with its dependency
 ```bash
 uv add pypdf
 # ... write code ...
-python3 -m pytest --cov=src --cov-fail-under=100
+uv run pytest --cov=src --cov-fail-under=100
 ```
 
 ### Run CI checks locally
@@ -233,7 +281,7 @@ python3 -m pytest --cov=src --cov-fail-under=100
 uv run ruff check .
 uv run ruff format . --check
 uv run mypy src/
-uv run python3 -m pytest --cov=src --cov-fail-under=100
+uv run pytest --cov=src --cov-fail-under=100
 ```
 
 ---
@@ -259,7 +307,7 @@ jobs:
         run: uv python install
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync
 
       - name: Lint
         run: uv run ruff check . --output-format=github
@@ -271,7 +319,7 @@ jobs:
         run: uv run mypy src/
 
       - name: Tests with coverage
-        run: uv run python3 -m pytest --cov=src --cov-fail-under=100
+        run: uv run pytest --cov=src --cov-fail-under=100
 ```
 
 ---

--- a/subagents/cli-agent.md
+++ b/subagents/cli-agent.md
@@ -43,7 +43,7 @@ my-cli-tool/
 ├── src/
 │   └── my_cli_tool/
 │       ├── __init__.py
-│       ├── __main__.py       # enables `python3 -m my_cli_tool`
+│       ├── __main__.py       # enables `uv run python -m my_cli_tool`
 │       ├── cli.py            # click/argparse entry point(s)
 │       ├── core.py           # business logic (no I/O dependencies)
 │       └── utils.py          # shared utilities
@@ -67,7 +67,8 @@ my-cli-tool/
 my-tool = "my_cli_tool.cli:main"
 ```
 
-After `uv pip install -e .`, users can run `my-tool` directly.
+After `uv sync` (which installs the project editable), users can run
+`uv run my-tool` directly.
 
 ---
 

--- a/subagents/release-agent.md
+++ b/subagents/release-agent.md
@@ -76,9 +76,9 @@ All of the following must pass on the release commit before tagging:
 
 ```bash
 pre-commit run --all-files          # secret scanning (RULES.md §8)
-ruff check .                        # no lint errors
-mypy src/                           # no type errors
-python3 -m pytest --cov=src --cov-fail-under=100   # 100% coverage
+uv run ruff check .                 # no lint errors
+uv run mypy src/                    # no type errors
+uv run pytest --cov=src --cov-fail-under=100      # 100% coverage
 pip-audit                           # no known dependency vulnerabilities
 ```
 

--- a/subagents/testing-agent.md
+++ b/subagents/testing-agent.md
@@ -20,16 +20,16 @@ Testing agents design, implement, and maintain test suites that:
 ## Quick Reference: Test Commands
 
 ```bash
-python3 -m pytest                              # run all tests
-python3 -m pytest tests/unit/                 # unit tests only
-python3 -m pytest tests/integration/          # integration tests only
-python3 -m pytest -x                          # stop on first failure
-python3 -m pytest -v                          # verbose (show test names)
-python3 -m pytest -k "tax"                    # filter by name fragment
-python3 -m pytest --cov=src --cov-report=term-missing   # coverage report
-python3 -m pytest --cov=src --cov-fail-under=100        # enforce 100%
-python3 -m pytest --tb=short                  # shorter traceback format
-python3 -m pytest --durations=10              # show 10 slowest tests
+uv run pytest                              # run all tests
+uv run pytest tests/unit/                 # unit tests only
+uv run pytest tests/integration/          # integration tests only
+uv run pytest -x                          # stop on first failure
+uv run pytest -v                          # verbose (show test names)
+uv run pytest -k "tax"                    # filter by name fragment
+uv run pytest --cov=src --cov-report=term-missing   # coverage report
+uv run pytest --cov=src --cov-fail-under=100        # enforce 100%
+uv run pytest --tb=short                  # shorter traceback format
+uv run pytest --durations=10              # show 10 slowest tests
 ```
 
 ---

--- a/templates/authorized_libraries.md
+++ b/templates/authorized_libraries.md
@@ -52,7 +52,7 @@ See RULES.md §5 for the full authorization process. Summary:
    - Library name and PyPI link
    - Proposed version constraint
    - Purpose and justification
-   - Output of `python3 -m pip_audit` showing no HIGH or CRITICAL vulnerabilities
+   - Output of `uv run pip-audit` showing no HIGH or CRITICAL vulnerabilities
 4. Do not add to `pyproject.toml`, or to `skills/approved-packages.md`, until a
    human approver has explicitly signed off. Amending the authoritative list is
    a human decision.

--- a/templates/onboarding-checklist.md
+++ b/templates/onboarding-checklist.md
@@ -41,9 +41,9 @@ derived from these templates. Complete all items before acting on any task.
 ## Step 4 — Confirm Toolchain
 
 - [ ] Run `uv sync` to install all dependencies.
-- [ ] Run `python3 -m pytest -x` to confirm the test suite passes.
-- [ ] Run `ruff check .` to confirm no lint errors.
-- [ ] Run `mypy src/` to confirm type correctness (if `src/` exists).
+- [ ] Run `uv run pytest -x` to confirm the test suite passes.
+- [ ] Run `uv run ruff check .` to confirm no lint errors.
+- [ ] Run `uv run mypy src/` to confirm type correctness (if `src/` exists).
 
 ## Step 5 — Understand Current State
 

--- a/templates/pyproject.toml
+++ b/templates/pyproject.toml
@@ -18,22 +18,18 @@ name = "<PROJECT_NAME>"
 version = "0.1.0"
 description = "<DESCRIPTION>"
 readme = "README.md"
-requires-python = ">=3.11"
-license = { text = "MIT" }
+requires-python = ">=3.12"
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [{ name = "<AUTHOR_NAME>", email = "<AUTHOR_EMAIL>" }]
 
-# Runtime dependencies — add with `uv add <package>`
+# Runtime dependencies: add with `uv add <package>`
 dependencies = []
 
-[project.optional-dependencies]
-# Development and CI dependencies — install with `uv sync --all-extras`
-dev = [
-    "pytest>=8.0",
-    "pytest-cov>=5.0",
-    "pytest-mock>=3.14",
-    "ruff>=0.4",
-    "mypy>=1.10",
-]
+# Optional *runtime* features consumers opt into via `<PROJECT_NAME>[extra]`.
+# Development tooling does NOT belong here; see [dependency-groups] below.
+# [project.optional-dependencies]
+# excel = ["openpyxl>=3.1"]
 
 # Uncomment if building a CLI tool with a console entry point
 # [project.scripts]
@@ -44,19 +40,24 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
+# An empty src/<PROJECT_NAME>/py.typed marker (PEP 561) is picked up
+# automatically by this include. No extra build configuration needed.
 packages = ["src/<PROJECT_NAME>"]
 
 # ---------------------------------------------------------------------------
-# uv
+# Dependency groups (PEP 735)
+#
+# Local development and CI tooling. Not published in package metadata.
+# Add with `uv add --dev <package>`; installed by a plain `uv sync`.
 # ---------------------------------------------------------------------------
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
     "pytest-mock>=3.14",
     "ruff>=0.4",
-    "mypy>=1.10",
+    "mypy>=1.12",   # 1.12 enables PEP 695 type-parameter syntax by default
 ]
 
 # ---------------------------------------------------------------------------
@@ -119,6 +120,7 @@ select = [
     "S",     # flake8-bandit (security)
     "N",     # pep8-naming
     "ANN",   # flake8-annotations
+    "D",     # pydocstyle (enforces the docstring rule in profiles/python.md)
     "RUF",   # ruff-specific rules
     "PT",    # flake8-pytest-style
     "SIM",   # flake8-simplify
@@ -130,10 +132,12 @@ ignore = [
     "D104",   # missing docstring in public package
     "D203",   # conflicts with D211
     "D213",   # conflicts with D212
-    "ANN101", # self annotation not required
-    "ANN102", # cls annotation not required
+    "D107",   # __init__ is documented by its class docstring
 ]
 fixable = ["ALL"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = [
@@ -149,14 +153,14 @@ fixable = ["ALL"]
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
-magic-trailing-comma = true
+skip-magic-trailing-comma = false   # preserve intentional trailing commas
 
 # ---------------------------------------------------------------------------
 # Mypy
 # ---------------------------------------------------------------------------
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 strict = true
 warn_return_any = true
 warn_unused_configs = true

--- a/templates/ruff.toml
+++ b/templates/ruff.toml
@@ -29,6 +29,7 @@ select = [
     "S",     # flake8-bandit (security)
     "N",     # pep8-naming
     "ANN",   # flake8-annotations
+    "D",     # pydocstyle (enforces the docstring rule in profiles/python.md)
     "RUF",   # ruff-specific rules
     "PT",    # flake8-pytest-style
     "SIM",   # flake8-simplify
@@ -41,8 +42,7 @@ ignore = [
     "D104",    # missing docstring in public package
     "D203",    # one-blank-line-before-class (conflicts with D211)
     "D213",    # multi-line-summary-second-line (conflicts with D212)
-    "ANN101",  # missing-type-self (self annotation not required)
-    "ANN102",  # missing-type-cls (cls annotation not required)
+    "D107",    # __init__ is documented by its class docstring
 ]
 
 fixable = ["ALL"]
@@ -73,5 +73,5 @@ convention = "google"  # "google", "numpy", or "pep257"
 [format]
 quote-style = "double"       # "double" or "single"
 indent-style = "space"       # "space" or "tab"
-magic-trailing-comma = true  # preserve intentional trailing commas
+skip-magic-trailing-comma = false  # preserve intentional trailing commas
 line-ending = "auto"         # "auto", "lf", or "crlf"


### PR DESCRIPTION
## Context

Triggered by reviewing [ncarsner/cyberdefense-mindmap-ad#11](https://github.com/ncarsner/cyberdefense-mindmap-ad/pull/11), which migrates `[tool.uv] dev-dependencies` to PEP 735 `[dependency-groups]`. That PR is correct, but **this repo carries the same defect one layer up**: `templates/pyproject.toml` had the deprecated table *and* a duplicate `dev` extra, so the next scaffolded project reproduces exactly what #11 just fixed.

`profiles/python.md` loads every agent session and the templates it governs are copied into every new project, so a contradiction here propagates.

Baseline unified on **Python 3.12**, which was already the value in `.python-version` and ruff's `target-version`.

## Contradictions resolved

Cases where the repo actively opposed a Final PEP, or contradicted itself.

| PEP | Was | Now |
|-----|-----|-----|
| 735 | `[tool.uv] dev-dependencies` + duplicate `dev` extra | single `[dependency-groups] dev` |
| 668 | `python3 -m pytest`, bare `ruff` / `mypy` | `uv run` everywhere |
| 563 / 649 | blanket `from __future__ import annotations` | quoted forward refs; `if TYPE_CHECKING:` `NameError` trap documented |
| 585 / 604 | hedged "Python >= 3.9 / >= 3.10" | unconditional; legacy `typing` aliases prohibited |
| 639 | `license = { text = "MIT" }` | SPDX string + `license-files` |
| ruff 0.8 | `ANN101` / `ANN102` ignores | removed |

Two of these were self-contradictions, not just PEP drift:

- **`uv pip install -e ".[dev]"`** sat in the mandatory-commands table of a profile whose own rule is "never use pip".
- **Bare `python3`** contradicted `RULES-BRIEF.md` §2, which already said "`python3` via `uv run`". The profile was the weaker of the two.

The `from __future__ import annotations` change is worth calling out: the import is not *wrong* on 3.12, but a blanket mandate breaks anything reading annotations at runtime (Pydantic, FastAPI route signatures, `dataclasses`), which conflicts with this repo's own `fastapi.md` and `django.md` profiles.

## Found while verifying

Three defects that reading alone would not have surfaced.

**1. The shipped template had a broken lint gate.** `magic-trailing-comma` is not a valid `[tool.ruff.format]` field (the real one is `skip-magic-trailing-comma`, inverted). `ruff check` **errored outright** on `templates/pyproject.toml` as shipped, so every project scaffolded from it inherited a non-functioning lint step. Pre-existing and outside the original scope.

**2. `RULES.md` §5 was silently under-scanning.** The mandatory security check ran `pip_audit --requirement <(uv pip compile pyproject.toml)`, which resolves `[project] dependencies` only. Measured on a probe project: `uv pip compile` resolved **5** packages, `uv export --all-groups` resolved **19**. Moving dev deps to PEP 735 without this companion edit would have dropped them from the scan entirely.

**3. The docstring rule had no enforcement.** Both templates ignored `D100`/`D104`/`D203`/`D213` but never *selected* `D`. It read as enforcement and was a no-op.

## Added

`raise ... from exc` (PEP 3134) with `from None` for deliberate suppression, `exc.add_note()` (678), `ExceptionGroup` / `except*` (654), `py.typed` (561), inline script metadata (723), `pylock.toml` (751).

PEP 695 / 692 / 698 are documented as **available, not mandatory** at 3.12. Runtime introspection of `type` aliases is still uneven, so a hard rule would bite.

## Scope note

The `uv run` sweep touched **20 files**, well beyond the profile: `CLAUDE.md`'s "After every Python edit" block, the profile's own Enforcement block, `.claude/skills/{test,format}`, `subagents/testing-agent.md`, and the `skills/python-*` references. Leaving any of them would have made the new rule contradict itself on first use.

No PEP catalog section was added. Every edit lands inside an existing section, with PEP numbers cited inline in rationale text.

## Verification

Materialized `templates/pyproject.toml` into a throwaway project and ran it:

- `uv sync` clean, **no uv deprecation warning** (the exact regression signal from #11)
- Editable install confirmed: importing from outside the project resolves into `src/`, not `site-packages`
- `ruff check` / `ruff format --check` clean, no unknown-rule warnings
- `D101`, `D102`, `D103` confirmed **firing**; `D107` confirmed ignored
- `mypy` passes at `python_version = "3.12"` with PEP 695 `def f[T](x: T) -> T`
- `pytest` at 100% coverage
- `py.typed` present in the built wheel with **no** `[tool.hatch.build]` include, so the profile documents that rather than adding dead config
- Rewritten §5 audit command run end to end; dev-group packages (pytest, ruff, mypy) appear in its output
- `templates/ruff.toml` verified separately on the standalone config path

One caveat: an early `D107` probe was contaminated by a stale `ruff.toml` left in the probe directory, which ruff resolved ahead of `pyproject.toml`. Re-run clean; results above are from the uncontaminated run.

## Not in this PR

Filed as issues: base-image inconsistency (`python:3.12-slim` vs `python:3.13-slim`), repo-wide em-dash violations against the `CLAUDE.md` writing style, and the mypy `unused section(s)` note in the template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)