### PR TITLE
fix(templates): resolve base image conflict, mypy noise, and docstring scope

### DIFF
--- a/profiles/python.md
+++ b/profiles/python.md
@@ -130,9 +130,9 @@ because installing into them is unsafe. Routing every invocation through
 
 ## Code Quality
 
-**Rule:** Every public module, class, function, and method MUST include a
-docstring, type hints on all parameters and return values, and inline comments
-where the logic is non-obvious.
+**Rule:** Every public module, class, function, and method under `src/` MUST
+include a docstring, type hints on all parameters and return values, and
+inline comments where the logic is non-obvious.
 
 ### Docstrings
 
@@ -166,6 +166,28 @@ This rule is enforced, not advisory. The project ruff config selects the `D`
 (pydocstyle) rule set with `convention = "google"`, so a missing or malformed
 docstring fails `ruff check`. A config that ignores `D1xx` codes without
 selecting `D` enforces nothing.
+
+**Scope: `src/`.** The rule exists to protect the package's public API, so that
+is where it is enforced. `tests/` is already exempt via `per-file-ignores` in
+`templates/pyproject.toml` and `templates/ruff.toml`.
+
+The CI examples in `skills/python-linting.md` and `skills/python-formatting.md`
+run `ruff check .` from the repository root, so a project that also keeps
+Python outside `src/` and `tests/` (`scripts/`, `noxfile.py`, `conftest.py`,
+`docs/conf.py`) will see `D` fire there too. None of that is public API. Add
+what the project actually has, rather than carrying entries for a layout it
+does not use:
+
+```toml
+[tool.ruff.lint.per-file-ignores]
+"scripts/**/*.py" = ["D"]
+"noxfile.py"      = ["D"]
+"conftest.py"     = ["D"]
+"docs/conf.py"    = ["D"]
+```
+
+The templates deliberately ship none of these. An unused ignore is its own kind
+of noise, and it hides the moment a directory starts holding real API.
 
 ### Type hints
 

--- a/skills/approved-packages.md
+++ b/skills/approved-packages.md
@@ -394,10 +394,17 @@ Use these stdlib modules before reaching for a third-party package.
 |---------|-----------|--------------|
 | Pre-commit hooks | `pre-commit` ★ | — |
 | CI/CD platform | GitHub Actions ★ | GitLab CI |
-| Docker base image | `python:3.13-slim` ★ | `python:3.13-alpine` |
+| Docker base image | `python:3.12-slim` ★ | `python:3.12-alpine` |
 | Environment variable injection | GitHub Secrets ★ | `.env` (local only) |
 | Code coverage service | `codecov` ★ | `coveralls` |
 | Dependency vulnerability scanning | `pip-audit` ★ | `safety` |
+
+The base image tracks the language baseline in `profiles/python.md`, currently
+Python 3.12 (`requires-python = ">=3.12"`, `target-version = "py312"`,
+`.python-version`). A newer image is legal, since `>=3.12` permits it, but the
+worked examples in `skills/containerization.md`,
+`subagents/containerization-agent.md`, `templates/Dockerfile`, and `RULES.md`
+all pin the baseline. Change this row only together with those.
 
 ---
 

--- a/templates/pyproject.toml
+++ b/templates/pyproject.toml
@@ -172,14 +172,21 @@ warn_unused_ignores = true
 no_implicit_reexport = true
 show_error_codes = true
 
-# Override for third-party libraries without stubs
-[[tool.mypy.overrides]]
-module = [
-    "pdfplumber.*",
-    "reportlab.*",
-    "questionary.*",
-    "schedule.*",
-    "dash.*",
-    "plotly.*",
-]
-ignore_missing_imports = true
+# Override for third-party libraries without stubs.
+#
+# Commented out deliberately. `warn_unused_configs = true` above reports every
+# module pattern that matched nothing, so shipping this block active makes a
+# fresh project's first `mypy` run print a note about six libraries it does not
+# depend on. Uncomment the block and list only the libraries the project
+# actually imports, adding each one as its dependency is added.
+#
+# [[tool.mypy.overrides]]
+# module = [
+#     "pdfplumber.*",
+#     "reportlab.*",
+#     "questionary.*",
+#     "schedule.*",
+#     "dash.*",
+#     "plotly.*",
+# ]
+# ignore_missing_imports = true


### PR DESCRIPTION
Closes #84
Closes #86
Closes #87

Three small template and config fixes, one commit each, independent of one another.

- `skills/approved-packages.md` - Docker base image row moves to 3.12, plus a note tying it to the language baseline
- `templates/pyproject.toml` - mypy overrides block commented out
- `profiles/python.md` - docstring rule scoped to `src/`, with the per-file-ignores a project may need

### Context

**#84** was the only real conflict. `approved-packages.md` marked `python:3.13-slim` preferred while `skills/containerization.md`, `subagents/containerization-agent.md`, `templates/Dockerfile`, and `RULES.md` all used 3.12. Since `approved-packages.md` is the §5 authority, an agent following it picked a value nothing else demonstrated. The repo baselines on 3.12 (`requires-python`, `target-version`, `.python-version`, mypy `python_version`), so the row moved rather than the four files that already agreed.

**#86** shipped a `[[tool.mypy.overrides]]` block for six libraries. With `warn_unused_configs = true`, every fresh project's first `mypy` run printed a note about libraries it does not depend on. Commented out, to be uncommented per library as deps are added.

**#87** followed the issue's own lean: state the scope, do not ship speculative ignores. `D` protects the package's public API, so `src/` is the boundary.

### Verified

Materialized `templates/pyproject.toml` into a real project and ran the tools, rather than reading the config.

- #84: all 17 `python:3.1x` references in the tree now read 3.12
- #86: A/B on the same probe. Active block prints `note: unused section(s): module = [...]`; commented block prints only `Success: no issues found in 2 source files`
- #87: with `scripts/` and `noxfile.py` present, `ruff check .` fires `D` 4 times outside `src/` and 0 times inside `src/` and `tests/`. The documented per-file-ignores snippet clears it