### PR TITLE
docs(skills): record ruff config-resolution precedence trap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `profiles/python.md` and `skills/python-uv-workflow.md`: PEP 723 inline script metadata as the pattern for one-off scripts, replacing `python3 src/<entry>.py`.
 - `profiles/python.md`: PEP 695 type parameters, PEP 692 `Unpack[TypedDict]`, and PEP 698 `@override` documented as available at 3.12 and explicitly not mandatory, since runtime introspection of `type` aliases is still uneven.
 - `skills/python-uv-workflow.md`: a lock-export section covering the audit requirements export and PEP 751 `pylock.toml`. `uv.lock` remains the source of truth.
+- `skills/python-linting.md`: a config-resolution section. A standalone `ruff.toml` takes precedence over `pyproject.toml` in the same directory, so a stray one silently shadows every `[tool.ruff]` setting. Recorded because it produced a wrong conclusion mid-session: a `D107` probe appeared to show the ignore list being disregarded, when ruff was in fact reading a leftover `ruff.toml` in the probe directory. Also notes that `--show-settings` prints `linter.rules.enabled` before `ignore` is applied, so a rule listed there may still never be reported.
 
 ---
 

--- a/skills/python-linting.md
+++ b/skills/python-linting.md
@@ -225,6 +225,42 @@ def create_user(data: UserData) -> User:
 
 ---
 
+## Config Resolution (a trap worth knowing)
+
+Ruff resolves configuration from the **nearest** config file walking up from
+each linted file, and a standalone `ruff.toml` or `.ruff.toml` **takes
+precedence over `pyproject.toml` in the same directory**. A stray `ruff.toml`
+left in a project root will silently shadow every `[tool.ruff]` setting in
+`pyproject.toml`.
+
+This matters when verifying a config change: if the run does not behave the way
+the config says it should, confirm which file ruff actually read before
+concluding the setting is broken.
+
+```bash
+# Print the resolved settings and, on the first lines, the config path used
+uv run ruff check --show-settings src/ | head -3
+```
+
+```
+Resolved settings for: "/path/to/project/src/pkg/__init__.py"
+Settings path: "/path/to/project/ruff.toml"     <- not pyproject.toml
+```
+
+Two related gotchas when reading `--show-settings` output:
+
+- `linter.rules.enabled` lists the **selected** rule set, before `ignore` is
+  applied. A rule appearing there does not mean it will be reported. Confirm
+  behavior by linting a file that violates it, not by reading the settings dump.
+- `[tool.ruff.lint.pydocstyle] convention` disables rules outside the chosen
+  convention, but does not re-enable anything you placed in `ignore`.
+
+Keep one config source per project. Prefer `[tool.ruff]` in `pyproject.toml`
+when that file exists, and use standalone `ruff.toml` only in projects without
+one.
+
+---
+
 ## Inline Suppressions
 
 Use sparingly and always include a reason:


### PR DESCRIPTION
Refs #91

Recovers the content of `61318c6` from the `pep-alignment` branch, which was never merged and carried an agent attribution trailer that `RULES.md` §18 prohibits without exception.

The content is byte-identical to the original (`git diff 61318c6 HEAD -- skills/python-linting.md` is empty). Only the trailer is gone. Recreated as a fresh commit off `main` rather than by amending `pep-alignment`, so nothing already pushed was rewritten.

### What it documents

A standalone `ruff.toml` takes precedence over `pyproject.toml` in the same directory, so a stray one silently shadows every `[tool.ruff]` setting. This produced a wrong conclusion during PEP alignment verification: a `D107` probe appeared to show the ignore list being disregarded, when ruff was actually reading a leftover `ruff.toml` in the probe directory.

Also notes that `--show-settings` prints `linter.rules.enabled` before `ignore` is applied, so a rule listed there may still never be reported. Behavior has to be confirmed by linting a violating file, not by reading the dump.

### After this merges

`pep-alignment` is redundant: 1 ahead, 6 behind, and its only commit is superseded here. Safe to delete.