### PR TITLE
feat(hooks): enforce §18 attribution rule with a commit-msg hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,11 @@
-# Pre-commit hook configuration for projects derived from agents-and-skills templates.
+# Pre-commit hooks for this repository.
 #
 # Setup:
-#   uv add --dev pre-commit detect-secrets
+#   uv add --dev pre-commit
 #   pre-commit install --hook-type pre-commit --hook-type commit-msg
-#   detect-secrets scan > .secrets.baseline
-#   git add .pre-commit-config.yaml .secrets.baseline
 #
-# Run manually against all files:
-#   pre-commit run --all-files
-#
-# Update hook versions:
-#   pre-commit autoupdate
+# The commit-msg hook is not installed by a bare `pre-commit install`.
+# Without --hook-type commit-msg the attribution check never runs.
 
 repos:
   - repo: local
@@ -25,18 +20,3 @@ repos:
         stages: [commit-msg]
         args: [--multiline, -i]
         entry: "^(?:[ \t>]*)(?:co-authored-by:[^\n]*(?:claude|anthropic|openai|chatgpt|gpt-[0-9]|copilot|gemini|codex|cursor|devin)|generated (?:with|by)[^\n]*(?:claude|anthropic|chatgpt|copilot|gemini|codex|cursor)|ai-generated|written by (?:claude|chatgpt|copilot|gemini|codex)|\U0001F916)"
-
-  - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.4.0
-    hooks:
-      - id: detect-secrets
-        args: ["--baseline", ".secrets.baseline"]
-        exclude: (\.secrets\.baseline|uv\.lock|poetry\.lock)$
-
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
-    hooks:
-      - id: detect-private-key
-      - id: check-added-large-files
-        args: ["--maxkb=500"]
-      - id: check-merge-conflict

--- a/RULES.md
+++ b/RULES.md
@@ -722,8 +722,37 @@ Agents must not author any text that appears in a version control artifact. Ever
 
 ### Enforcement
 
+Human review does not catch this. The trailer is appended by tooling at commit
+time, so it is not part of the change a reviewer is reading. Eight commits in
+this repository's own history carried one before any check existed.
+
+Install the `commit-msg` hook from
+[templates/.pre-commit-config.yaml](templates/.pre-commit-config.yaml):
+
+```bash
+uv add --dev pre-commit
+pre-commit install --hook-type pre-commit --hook-type commit-msg
+```
+
+A bare `pre-commit install` wires only the `pre-commit` stage, which never sees
+the commit message. Without `--hook-type commit-msg` the check silently does
+not run.
+
+The hook matches a trailer or footer **line**, anchored, naming an agent
+vendor. It does not match the phrase appearing in prose, so a commit may still
+describe this rule, and it does not match a `Co-Authored-By:` trailer naming a
+human, which stays legitimate.
+
+**A local hook cannot cover every path.** Commits created in the GitHub web UI,
+including accepting a Copilot Autofix suggestion, are built server side and
+never run local hooks. Five of the eight historical violations arrived that
+way. Reviewers must still reject those on the pull request, and a CI check on
+the PR's commit range is the only mechanical backstop.
+
+Alongside the hook:
+
 - Human review must confirm no attribution markers are present before merging. See §19 review checklist.
-- When an AI tool adds a `Co-Authored-By:` trailer by default (as many do), the human must remove it before committing. Do not rely on a hook to strip these: trailer formats change across tool versions.
+- When an AI tool adds a `Co-Authored-By:` trailer by default (as many do), the human must remove it before committing.
 - The git author identity must always reflect the human who owns the work.
 
 ### What agents may do


### PR DESCRIPTION
Refs #91

Stacked on #95. Leaves #91 open: the CI backstop remains, and it is the larger half. See below.

§18 prohibited agent attribution in commits but declined to enforce it, reasoning that trailer formats vary across tool versions. Eight commits in this repository's history carry one, so review plus a checklist item has not worked. The trailer is appended by tooling at commit time, which is exactly when a reviewer reading a diff will not see it.

### What this adds

A `pygrep` hook at the `commit-msg` stage, in this repo's new `.pre-commit-config.yaml` and in `templates/.pre-commit-config.yaml` so downstream projects inherit the enforcement rather than only the prohibition. `RULES.md` §18 gains an Enforcement section replacing the sentence that declined a hook.

The pattern matches an anchored trailer or footer line naming an agent vendor. Two false-positive classes it must not hit, both real in this tree: a message that describes the rule in prose, which this repo's docs and skills do constantly, and a `Co-Authored-By:` trailer naming a human, which stays legitimate.

### Verified against real history, not synthetic cases

Replayed every commit in the repository through the installed hook:

- all 8 real violations blocked
- `7964ab5`, which only mentions the mechanism in prose, allowed
- human co-author trailer allowed
- every commit from this session allowed
- a live commit carrying a trailer was rejected, with the offending line named

### Two traps worth keeping

- pygrep's `--multiline` sets `re.DOTALL`, so `.*` spans newlines. The pattern uses `[^\n]*` or it matches across lines and produces false positives.
- A bare `pre-commit install` wires only the `pre-commit` stage, which never sees the message. `--hook-type commit-msg` is required or the check silently does not run. Documented in §18 and both config headers.

### What this does not cover

Five of the eight historical violations came from GitHub Copilot Autofix, committed server side in the web UI. **Local hooks never run on those.** §18 documents the limit rather than implying the hook is sufficient. A CI check over the pull request's commit range is the only mechanical backstop, and is left open on #91.

### Note for the reviewer

Installing here required `git config --unset-all core.hooksPath`. It was set locally to git's own default hooks directory, and pre-commit refuses to install while it is set at all. That is a local config change, not part of this diff.