### PR TITLE
docs(session): 2026-09-04 session close, capture reusable patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .file_list
 *-session.md
 .claude/worktrees/
+writing-styles/
 
 # Python
 __pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## 2026-09-04
+
+### Added
+- `skills/pre-commit-hooks.md`: authoring `pre-commit` and `commit-msg` hooks. Covers the `pygrep` local-hook form that needs no external dependency, why `--multiline` enabling `re.DOTALL` makes `.*` cross newlines, anchoring a pattern so a repository can still commit its own documentation of a prohibited string, `core.hooksPath` blocking installation even when set to the default path, and the limit that no local hook sees a commit created in the GitHub web UI. Registered in `skills/skills.md`.
+- `.pre-commit-config.yaml` and a matching block in `templates/.pre-commit-config.yaml`: a `commit-msg` hook rejecting agent attribution trailers, so downstream projects inherit the enforcement rather than only the prohibition. `RULES.md` §18 gained an Enforcement section replacing the sentence that declined a hook. Verified by replaying every commit in the repository's history: all 8 real violations blocked, prose mentions and human co-author trailers allowed.
+- `skills/github-issue-creation.md`: a section on closing keywords and stacked pull requests. GitHub's parser matches a closing keyword next to an issue number even when the sentence negates it, and merging a stacked PR with `--delete-branch` closes every PR based on the deleted branch. Both are recorded because both closed real issues here.
+
+### Changed
+- Canonical instruction file renamed from `CLAUDE.md` to `AGENTS.md`, the cross-agent convention. The root `CLAUDE.md` is now a stub. 37 files, 175 references. Resolves the file-versus-directory objection by establishing that `AGENTS.md` and `AGENTS/` are never in the same place.
+- `RULES.md` §5 audit command carries `--disable-pip`. It is required by the interpreter uv installs by default, not a fallback for a broken machine: pip-audit creates its environment with `venv.EnvBuilder(with_pip=True)`, which copies rather than symlinks the interpreter, and python-build-standalone builds are not relocatable by copy. Both forms report identical findings; the flagged form runs 13x faster.
+- Docker base image guidance unified on `python:3.12-slim` across all 17 references, tracking the language baseline rather than diverging from it.
+- `profiles/python.md` docstring rule scoped to `src/`, with the per-file-ignores a project may need documented rather than shipped unused.
+- `templates/pyproject.toml` mypy overrides commented out, so a fresh project's first `mypy` run no longer reports unused sections for six libraries it does not depend on.
+
+### Fixed
+- All 906 em dashes removed across 93 files, applied retroactively without exemption. Only the `AGENTS.md` Writing Style line that quotes the character survives.
+- 77 broken markdown anchors repaired, a pre-existing defect surfaced while checking that the em dash scrub would not break the `RULES.md` table of contents. All 19 TOC links and 58 cross-file links into `RULES.md` omitted the scope marker (`[CORE]`, `[LANG:PYTHON]`) that GitHub folds into the anchor. `RULES-BRIEF.md` also pointed "Code Review and Approval Workflow" at §18, which is Authorship and Attribution; it is §19.
+- `index.md` Repo Reference Docs rows pointed at gitignored paths, so a keyword grep reported a hit and then routed the agent to a file absent from any fresh clone. Repointed at `CHANGELOG.md` date headings, and `/epilogue` gained Step 5a so a routine close keeps the catalog current.
+- `sessions/` resolved to two directories downstream. Pages are project-root state, since they are git-tracked and `AGENTS/` is never committed; only the format spec ships with the bundle. `RULES.md` §12 gained "Path references inside bundle documents" recording the general constraint.
+
+### Note
+- Two items remain out of reach from this repository. The copy mechanism that seeds downstream projects still ships `CLAUDE.md` and keys its stub detection on `See AGENTS/CLAUDE.md`, which no longer appears in the tree (#79). Local hooks cannot see commits created in the GitHub web UI, which produced five of the eight historical attribution violations, so a CI check over each pull request's commit range is still needed (#91).
+
+---
+
 ## 2026-08-30
 
 ### Changed

--- a/index.md
+++ b/index.md
@@ -50,3 +50,4 @@ Existing dated docs, indexed for keyword lookup until migrated into the
 | 2026-06-18 | authorship, attribution, RULES.md §18, co-authored-by | `CHANGELOG.md` [2026-06-18](CHANGELOG.md#2026-06-18) |
 | 2026-07-12 | rules-drafts cleanup, registry drift, AGENTS.md consolidation, epilogue command | `CHANGELOG.md` [2026-07-12](CHANGELOG.md#2026-07-12) |
 | 2026-07-29 | issue triage, content catalog, index.md, sessions wiki format | `CHANGELOG.md` [2026-07-29](CHANGELOG.md#2026-07-29) |
+| 2026-09-04 | AGENTS.md rename, em dash scrub, markdown anchors, attribution hook, pip-audit flags | `CHANGELOG.md` [2026-09-04](CHANGELOG.md#2026-09-04) |

--- a/skills/github-issue-creation.md
+++ b/skills/github-issue-creation.md
@@ -225,6 +225,58 @@ asked for it, or the user explicitly delegated triage of open issues.
 
 ---
 
+## Closing Keywords and Stacked Pull Requests
+
+Two failure modes, both observed closing real issues in this repository.
+
+### A closing keyword fires even when negated
+
+GitHub's parser scans a PR body for `close`, `fixes`, `resolves` and friends
+adjacent to an issue number. It has no notion of negation, so writing a
+sentence explaining that a PR does *not* close an issue is what closes it:
+
+```
+Does not close #91: the CI backstop remains open.   <- closes #91 on merge
+Leaves #91 open: the CI backstop remains.           <- safe
+```
+
+Never put a closing keyword next to an issue number unless you intend the
+close. Phrase the negative as "leaves #N open" or "#N remains open". A `Refs
+#N` header does not protect you; the prose is scanned too.
+
+Use `Closes` only for issues the PR actually resolves. A PR that finishes half
+an issue carries `Refs`, and the remaining tasks are recorded on the issue
+before merge, otherwise the merge buries them.
+
+### Merging a stack deletes the wrong things
+
+When PR B is based on PR A's branch, merging A with `--delete-branch` removes
+B's base branch, and GitHub **closes** B. A closed PR cannot be retargeted and
+cannot be reopened while its base is missing, so the recovery is awkward:
+
+```bash
+git push origin <sha>:refs/heads/<deleted-base>   # restore the base
+gh pr reopen <B> --repo OWNER/REPO
+gh pr edit <B> --repo OWNER/REPO --base main
+```
+
+Merge a stack bottom-up, retargeting before each merge, and delete branches
+only for the leaf:
+
+```bash
+gh pr merge <A> --repo OWNER/REPO --merge                 # base of another PR
+gh pr edit  <B> --repo OWNER/REPO --base main             # retarget first
+gh pr merge <B> --repo OWNER/REPO --merge --delete-branch # leaf
+```
+
+Verify what actually closed rather than assuming the keywords behaved:
+
+```bash
+gh issue view <N> --repo OWNER/REPO --json state,closedByPullRequestsReferences
+```
+
+---
+
 ## Safety Constraints
 
 - Treat GitHub issue creation as an external write operation.

--- a/skills/pre-commit-hooks.md
+++ b/skills/pre-commit-hooks.md
@@ -1,0 +1,128 @@
+# Skill: Pre-commit Hooks
+
+Writing and installing `pre-commit` hooks, including the `commit-msg` stage,
+and the traps that make a hook silently not run or match the wrong thing.
+
+---
+
+## Quick Reference
+
+```bash
+uv add --dev pre-commit
+pre-commit install --hook-type pre-commit --hook-type commit-msg
+pre-commit validate-config .pre-commit-config.yaml
+pre-commit run --hook-stage commit-msg --commit-msg-filename <file> <hook-id>
+```
+
+| Symptom | Cause |
+|---------|-------|
+| Message-checking hook never fires | `pre-commit install` alone skips the `commit-msg` stage |
+| `Cowardly refusing to install hooks` | `core.hooksPath` is set, even to the default path |
+| Pattern matches text on another line | `--multiline` enables `re.DOTALL`, so `.` crosses newlines |
+| Hook blocks a commit that only documents the rule | Pattern is unanchored, matching prose as well as trailers |
+
+---
+
+## Pattern: A commit-msg Hook with No External Dependency
+
+`language: pygrep` keeps the whole check inside the YAML, so nothing has to be
+installed and no script file has to ship with the config. A pygrep hook
+**fails when the pattern matches**, which is what a prohibition wants.
+
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: no-agent-attribution
+        name: reject agent attribution trailers
+        language: pygrep
+        stages: [commit-msg]
+        args: [--multiline, -i]
+        entry: "^(?:[ \t>]*)(?:co-authored-by:[^\n]*(?:claude|copilot|chatgpt)|\U0001F916)"
+```
+
+At the `commit-msg` stage pre-commit passes the commit message file as the
+hook's filename, so the pattern runs against the message, not the diff.
+
+---
+
+## Pattern: Anchor the Match, or Documentation Cannot Be Committed
+
+A repository that documents a prohibited string contains that string. An
+unanchored pattern blocks the very commit that adds the documentation.
+
+Match the structural form, not the words:
+
+```
+^co-authored-by:[^\n]*<vendor>     matches a trailer line
+.*co-authored-by.*                 also matches "we prohibit Co-Authored-By"
+```
+
+Test both directions before shipping. The allow cases matter as much as the
+block cases:
+
+- a real trailer, several vendor spellings and letter cases
+- the same phrase inside ordinary prose
+- a trailer naming a human, which stays legitimate
+- the detection regex itself, quoted in a skill or doc
+
+Replay real history rather than synthetic strings:
+
+```bash
+git log --all --format='%H' | while read -r c; do
+  git log -1 --format=%B "$c" > /tmp/m.txt
+  pre-commit run --hook-stage commit-msg --commit-msg-filename /tmp/m.txt <id> \
+    >/dev/null 2>&1 || echo "would block $c"
+done
+```
+
+---
+
+## Pattern: `--multiline` Turns On DOTALL
+
+pre-commit's pygrep sets `re.MULTILINE | re.DOTALL` together. `.` then matches
+newlines, so `^label:.*keyword` can match a `label:` on one line and a
+`keyword` many lines below.
+
+Use `[^\n]*` for "rest of this line". `.*` is almost never what you want in a
+multiline pygrep pattern.
+
+---
+
+## Pattern: `core.hooksPath` Blocks Installation
+
+pre-commit refuses to install while `core.hooksPath` is set, even when it
+points at `.git/hooks`, the default. The message names the cause:
+
+```
+[ERROR] Cowardly refusing to install hooks with `core.hooksPath` set.
+```
+
+```bash
+git config --get core.hooksPath        # check before assuming install worked
+git config --unset-all core.hooksPath  # no-op when it pointed at the default
+```
+
+Always confirm the hook file exists rather than trusting the install output:
+
+```bash
+ls -l .git/hooks/commit-msg
+```
+
+---
+
+## Limits Worth Documenting
+
+A local hook only runs on a local commit. Commits created in the GitHub web
+UI, including accepting a Copilot Autofix suggestion, are built server side
+and never run one. Where a rule must hold for every commit, pair the hook with
+a CI check over the pull request's commit range and say so in the rule, rather
+than implying the hook is sufficient.
+
+---
+
+## See Also
+
+- [`skills/secret-scanning.md`](secret-scanning.md)
+- [`templates/.pre-commit-config.yaml`](../templates/.pre-commit-config.yaml)
+- [`RULES.md` §18](../RULES.md#18-authorship-and-attribution-core)

--- a/skills/skills.md
+++ b/skills/skills.md
@@ -15,6 +15,7 @@ recipes, and code cookbooks. They are read on demand when an agent needs to know
 | File | Domain | When to load |
 |------|--------|--------------|
 | [`python-formatting.md`](python-formatting.md) | All | ruff format configuration and usage |
+| [`pre-commit-hooks.md`](pre-commit-hooks.md) | All | pre-commit and commit-msg hook authoring, pygrep traps, install pitfalls |
 | [`python-linting.md`](python-linting.md) | All | ruff lint rules and mypy configuration |
 | [`python-testing.md`](python-testing.md) | All | pytest, coverage, fixtures, mocking cookbook |
 | [`python-uv-workflow.md`](python-uv-workflow.md) | All | uv package manager complete reference |


### PR DESCRIPTION
Session close for 2026-09-04. Records three traps this session hit, each of which closed or broke something real here, plus the CHANGELOG and catalog entries.

- `skills/pre-commit-hooks.md` - new, registered in `skills/skills.md`
- `skills/github-issue-creation.md` - closing keywords and stacked pull requests
- `CHANGELOG.md` - 2026-09-04 entry
- `index.md` - catalog row pointing at it

### Why these are worth writing down

**pygrep `--multiline` enables `re.DOTALL`.** `.*` then crosses newlines, so an anchored pattern can match a label on one line against a keyword far below. Use `[^\n]*`.

**Anchor the pattern or the repo cannot document its own rule.** A tree that documents a prohibited string contains it. An unanchored match blocks the commit that adds the documentation.

**`core.hooksPath` blocks `pre-commit install`** even when set to git's own default path, and the install failure is easy to miss.

**GitHub matches a negated closing keyword.** "Does not close #91" closed #91 on the merge of #96 during this session.

**`--delete-branch` on a stacked PR closes the dependent PR**, and a closed PR can be neither retargeted nor reopened while its base branch is missing. That happened to #93 and needed the base branch pushed back to origin to recover.

### Verified

- `git grep -c "em dash"` returns `AGENTS.md:1`
- 0 broken anchors repo-wide, including the new skill's link into `RULES.md` §18
- the attribution hook ran on this commit and passed
- `index.md` row target passes `git ls-files --error-unmatch`

### Also in this PR

`writing-styles/` added to `.gitignore`. Present since 2026-08-10 and surfacing as untracked noise in every `git status`, it holds local-only per-author prose style guides. Ignored rather than committed: nothing in it is imported by a skill, subagent, or template, and prose style references are outside what this repository governs. Placed with the other project-specific local artifacts (`.file_list`, `*-session.md`, `.claude/worktrees/`).